### PR TITLE
feat(config): add environment variable overrides

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -24,6 +24,28 @@ log_level: info
 enabled_plugins: []  # empty = all enabled
 ```
 
+### Environment Variable Overrides
+
+Environment variables override YAML values. Set any combination:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `CM_LISTEN_HOST` | Bind address | `0.0.0.0` |
+| `CM_LISTEN_PORT` | Listen port | `9090` |
+| `CM_LOG_LEVEL` | Log level (`debug`, `info`, `warn`, `error`) | `debug` |
+| `CM_ENABLED_PLUGINS` | Comma-separated plugin allowlist | `update,network` |
+
+```bash
+# Override port and log level
+CM_LISTEN_PORT=9090 CM_LOG_LEVEL=debug ./cm
+
+# Restrict to specific plugins
+CM_ENABLED_PLUGINS=update ./cm
+```
+
+Invalid `CM_LISTEN_PORT` values are ignored with a warning; the YAML or
+default value is kept.
+
 ## Building
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -39,6 +41,7 @@ func Load(path string) (*Config, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			slog.Info("config file not found, using defaults", "path", path)
+			applyEnv(cfg)
 			return cfg, nil
 		}
 		return nil, err
@@ -48,5 +51,43 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	applyEnv(cfg)
 	return cfg, nil
+}
+
+// applyEnv overrides config fields with environment variables when set.
+// Supported variables: CM_LISTEN_HOST, CM_LISTEN_PORT, CM_LOG_LEVEL,
+// CM_ENABLED_PLUGINS (comma-separated).
+func applyEnv(cfg *Config) {
+	if v := os.Getenv("CM_LISTEN_HOST"); v != "" {
+		cfg.ListenHost = v
+	}
+	if v := os.Getenv("CM_LISTEN_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil {
+			if port < 1 || port > 65535 {
+				slog.Warn("ignoring out-of-range CM_LISTEN_PORT", "value", v)
+			} else {
+				cfg.ListenPort = port
+			}
+		} else {
+			slog.Warn("ignoring invalid CM_LISTEN_PORT", "value", v)
+		}
+	}
+	if v := os.Getenv("CM_LOG_LEVEL"); v != "" {
+		cfg.LogLevel = v
+	}
+	if v := os.Getenv("CM_ENABLED_PLUGINS"); v != "" {
+		var plugins []string
+		for _, p := range strings.Split(v, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				plugins = append(plugins, p)
+			}
+		}
+		if len(plugins) > 0 {
+			cfg.EnabledPlugins = plugins
+		} else {
+			slog.Warn("ignoring CM_ENABLED_PLUGINS with no valid entries", "value", v)
+		}
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,7 +22,18 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+// clearCMEnv ensures no CM_* environment variables leak into tests that
+// call Load() and assert on default/YAML values.
+func clearCMEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CM_LISTEN_HOST", "")
+	t.Setenv("CM_LISTEN_PORT", "")
+	t.Setenv("CM_LOG_LEVEL", "")
+	t.Setenv("CM_ENABLED_PLUGINS", "")
+}
+
 func TestLoadMissingFile(t *testing.T) {
+	clearCMEnv(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nonexistent.yaml")
 	cfg, err := Load(path)
@@ -36,6 +47,7 @@ func TestLoadMissingFile(t *testing.T) {
 }
 
 func TestLoadValidYAML(t *testing.T) {
+	clearCMEnv(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 
@@ -83,6 +95,7 @@ func TestLoadInvalidYAML(t *testing.T) {
 }
 
 func TestLoadEmptyPath(t *testing.T) {
+	clearCMEnv(t)
 	// Empty path falls back to defaultConfigPath (/etc/cm/config.yaml).
 	// On most test machines this doesn't exist, so we get defaults.
 	// Skip if it happens to exist to keep the test hermetic.
@@ -95,5 +108,135 @@ func TestLoadEmptyPath(t *testing.T) {
 	}
 	if cfg.ListenPort != 8080 {
 		t.Fatalf("got port %d, want default 8080", cfg.ListenPort)
+	}
+}
+
+func TestApplyEnv_OverridesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.yaml")
+
+	t.Setenv("CM_LISTEN_HOST", "0.0.0.0")
+	t.Setenv("CM_LISTEN_PORT", "9090")
+	t.Setenv("CM_LOG_LEVEL", "debug")
+	t.Setenv("CM_ENABLED_PLUGINS", "update,network")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenHost != "0.0.0.0" {
+		t.Errorf("host: got %q, want %q", cfg.ListenHost, "0.0.0.0")
+	}
+	if cfg.ListenPort != 9090 {
+		t.Errorf("port: got %d, want %d", cfg.ListenPort, 9090)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("log_level: got %q, want %q", cfg.LogLevel, "debug")
+	}
+	if len(cfg.EnabledPlugins) != 2 || cfg.EnabledPlugins[0] != "update" || cfg.EnabledPlugins[1] != "network" {
+		t.Errorf("enabled_plugins: got %v, want [update network]", cfg.EnabledPlugins)
+	}
+}
+
+func TestApplyEnv_OverridesYAML(t *testing.T) {
+	clearCMEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yamlData := `listen_host: "127.0.0.1"
+listen_port: 3000
+log_level: "warn"
+`
+	if err := os.WriteFile(path, []byte(yamlData), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	t.Setenv("CM_LISTEN_PORT", "4000")
+	t.Setenv("CM_LOG_LEVEL", "error")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// YAML value kept when env not set
+	if cfg.ListenHost != "127.0.0.1" {
+		t.Errorf("host: got %q, want %q (from YAML)", cfg.ListenHost, "127.0.0.1")
+	}
+	// Env overrides YAML
+	if cfg.ListenPort != 4000 {
+		t.Errorf("port: got %d, want %d (from env)", cfg.ListenPort, 4000)
+	}
+	if cfg.LogLevel != "error" {
+		t.Errorf("log_level: got %q, want %q (from env)", cfg.LogLevel, "error")
+	}
+}
+
+func TestApplyEnv_InvalidPort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.yaml")
+
+	t.Setenv("CM_LISTEN_PORT", "not-a-number")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should keep default when port is invalid
+	if cfg.ListenPort != 8080 {
+		t.Errorf("port: got %d, want default 8080", cfg.ListenPort)
+	}
+}
+
+func TestApplyEnv_OutOfRangePort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.yaml")
+
+	for _, port := range []string{"0", "-1", "65536", "99999"} {
+		t.Run(port, func(t *testing.T) {
+			t.Setenv("CM_LISTEN_PORT", port)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.ListenPort != 8080 {
+				t.Errorf("port %s: got %d, want default 8080", port, cfg.ListenPort)
+			}
+		})
+	}
+}
+
+func TestApplyEnv_PluginsWithWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.yaml")
+
+	t.Setenv("CM_ENABLED_PLUGINS", " update , , network ")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.EnabledPlugins) != 2 || cfg.EnabledPlugins[0] != "update" || cfg.EnabledPlugins[1] != "network" {
+		t.Errorf("enabled_plugins: got %v, want [update network]", cfg.EnabledPlugins)
+	}
+}
+
+func TestApplyEnv_PluginsWhitespaceOnlyPreservesYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yamlData := `enabled_plugins:
+  - update
+`
+	if err := os.WriteFile(path, []byte(yamlData), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	t.Setenv("CM_ENABLED_PLUGINS", " , , ")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Whitespace-only should be ignored, preserving YAML value
+	if len(cfg.EnabledPlugins) != 1 || cfg.EnabledPlugins[0] != "update" {
+		t.Errorf("enabled_plugins: got %v, want [update]", cfg.EnabledPlugins)
 	}
 }


### PR DESCRIPTION
## Summary

Add environment variable overrides for configuration. Env vars override YAML values and defaults.

### Supported Variables

| Variable | Description | Example |
|----------|-------------|---------|
| CM_LISTEN_HOST | Bind address | 0.0.0.0 |
| CM_LISTEN_PORT | Listen port | 9090 |
| CM_LOG_LEVEL | Log level | debug |
| CM_ENABLED_PLUGINS | Comma-separated plugin allowlist | update,network |

### Changes

- **internal/config/config.go**: New \pplyEnv()\ function called after YAML load and on defaults fallback
- **internal/config/config_test.go**: 5 new tests (override defaults, override YAML, invalid port, whitespace plugins, empty path)
- **docs/USAGE.md**: Environment variable documentation section

### Testing

- All existing + new tests pass
- golangci-lint clean

Closes #3