### PR TITLE
chore: add markdownlint CI and unify docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Target platforms: Raspbian Bookworm (ARM64), Debian Bullseye slim.
 
 - **Entry point**: `cmd/cm/main.go` — parses flags, loads config, initializes plugins/scheduler/API, starts TUI
 - **Plugin interface**: `plugin/plugin.go` — defines the `Plugin` interface that all plugins implement
-- **Plugin registry**: `plugin/registry.go` — global registry; plugins self-register via `init()`
+- **Plugin registry**: `plugin/registry.go` — global registry; plugins registered explicitly in `main.go`
 - **Configuration**: `internal/config/config.go` — YAML config with struct tags
 - **API server**: `internal/api/server.go` — Chi router, runs in a goroutine alongside TUI
 - **API routes**: `internal/api/routes.go` — core endpoints: health, node info, plugins, jobs
@@ -20,13 +20,16 @@ Target platforms: Raspbian Bookworm (ARM64), Debian Bullseye slim.
 ## Plugin Model
 
 Plugins are separate Go modules in their own repos:
+
 - `github.com/msutara/cm-plugin-update` — OS/package update management
 - `github.com/msutara/cm-plugin-network` — network configuration
 
 Each plugin:
+
 1. Implements `plugin.Plugin` interface
-2. Calls `plugin.Register()` in an `init()` function
-3. Is imported in `cmd/cm/main.go` with a blank import: `import _ "github.com/msutara/cm-plugin-update"`
+2. Exports a constructor (e.g., `NewUpdatePlugin()`)
+3. Is imported and registered explicitly in `cmd/cm/main.go`:
+   `plugin.Register(update.NewUpdatePlugin())`
 
 ## Conventions
 
@@ -42,6 +45,7 @@ Each plugin:
 ## Specifications
 
 Agent-readable specifications live in `specs/`:
+
 - `specs/SPEC.md` — what the core does and doesn't do
 - `specs/ARCHITECTURE.md` — directory layout, components, startup sequence
 - `specs/PLUGIN-INTERFACE.md` — the Plugin interface contract
@@ -53,5 +57,5 @@ User-facing documentation lives in `docs/`.
 
 - All Go code must pass `golangci-lint run`
 - All tests must pass: `go test ./...`
-- CI runs lint + test via `.github/workflows/ci.yml`
+- CI runs markdownlint + lint + test via `.github/workflows/ci.yml`
 - Never push directly to main — always use feature branches and PRs

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -1,6 +1,6 @@
 # How It Works
 
-## Architecture
+## 1. System Design
 
 Config Manager Core is a single Go binary that embeds:
 
@@ -31,15 +31,15 @@ Config Manager Core is a single Go binary that embeds:
 └─────────────────────────────────────┘
 ```
 
-## Plugin Model
+## 2. Plugin Model
 
 Plugins are separate Go modules compiled into the core binary at build time:
 
 1. Each plugin implements the `Plugin` interface (see [PLUGIN-INTERFACE.md](../specs/PLUGIN-INTERFACE.md)).
-2. Plugins self-register via Go `init()` functions.
-3. Adding a plugin = one `import` line in `cmd/cm/main.go` + rebuild.
+2. Plugins export constructors and are registered explicitly in `cmd/cm/main.go`.
+3. Adding a plugin = one import + `plugin.Register()` call in `cmd/cm/main.go` + rebuild.
 
-## Startup Sequence
+## 3. Startup Sequence
 
 1. Parse CLI flags.
 2. Load config from YAML (default: `/etc/cm/config.yaml`).
@@ -51,7 +51,7 @@ Plugins are separate Go modules compiled into the core binary at build time:
 8. Block until SIGINT/SIGTERM (Phase 1) or TUI exit (Phase 2).
 9. On exit: gracefully shut down API server and scheduler.
 
-## Configuration
+## 4. Configuration
 
 YAML-based configuration loaded from a YAML file.
 See [USAGE.md](USAGE.md) for details.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-## CLI Options
+## 1. CLI Options
 
 ```text
 Usage: cm [OPTIONS]
@@ -11,7 +11,7 @@ Options:
   -help, --help   Show help message
 ```
 
-## Configuration
+## 2. Configuration
 
 CM Core reads configuration from a YAML file. If not found, defaults are used.
 
@@ -46,7 +46,7 @@ CM_ENABLED_PLUGINS=update ./cm
 Invalid `CM_LISTEN_PORT` values are ignored with a warning; the YAML or
 default value is kept.
 
-## Building
+## 3. Building
 
 ```bash
 # Native build
@@ -59,7 +59,7 @@ GOOS=linux GOARCH=arm64 go build -o cm ./cmd/cm
 GOOS=linux GOARCH=arm GOARM=7 go build -o cm ./cmd/cm
 ```
 
-## Running
+## 4. Running
 
 ```bash
 # Run with defaults
@@ -72,7 +72,7 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o cm ./cmd/cm
 ./cm --version
 ```
 
-## Deployment
+## 5. Deployment
 
 Copy the binary to your node and run as a systemd service:
 

--- a/specs/API.md
+++ b/specs/API.md
@@ -1,12 +1,18 @@
 # Config Manager Core — API Specification
 
-Base path: `/api/v1`
+## 1. Overview
 
 All responses are JSON. Errors use a common error format.
 
 ---
 
-## 1. Error format
+## 2. Base URL
+
+Base path: `/api/v1`
+
+---
+
+## 3. Error Format
 
 On error, endpoints return:
 
@@ -22,9 +28,9 @@ On error, endpoints return:
 
 ---
 
-## 2. Core endpoints
+## 4. Core Endpoints
 
-### 2.1. `GET /api/v1/health`
+### 4.1. `GET /api/v1/health`
 
 Health check for the core service.
 
@@ -39,7 +45,7 @@ Health check for the core service.
 
 ---
 
-### 2.2. `GET /api/v1/node`
+### 4.2. `GET /api/v1/node`
 
 Basic node/system information.
 
@@ -57,7 +63,7 @@ Basic node/system information.
 
 ---
 
-### 2.3. `GET /api/v1/plugins`
+### 4.3. `GET /api/v1/plugins`
 
 List loaded plugins.
 
@@ -80,7 +86,7 @@ List loaded plugins.
 
 ---
 
-### 2.4. `GET /api/v1/plugins/{name}`
+### 4.4. `GET /api/v1/plugins/{name}`
 
 Get metadata for a specific plugin.
 
@@ -112,7 +118,7 @@ Get metadata for a specific plugin.
 
 ---
 
-### 2.5. `GET /api/v1/jobs`
+### 4.5. `GET /api/v1/jobs`
 
 List scheduled jobs from all plugins.
 
@@ -121,14 +127,14 @@ List scheduled jobs from all plugins.
 ```json
 [
   {
-    "id": "update.run_security",
+    "id": "update.security",
     "plugin": "update",
     "description": "Run security updates",
     "schedule": "0 3 * * *",
     "next_run_time": null
   },
   {
-    "id": "update.run_full",
+    "id": "update.full",
     "plugin": "update",
     "description": "Run full upgrade",
     "schedule": null,
@@ -142,7 +148,7 @@ List scheduled jobs from all plugins.
 
 ---
 
-### 2.6. `POST /api/v1/jobs/trigger`
+### 4.6. `POST /api/v1/jobs/trigger`
 
 Trigger a job by ID.
 
@@ -150,7 +156,7 @@ Trigger a job by ID.
 
 ```json
 {
-  "job_id": "update.run_full"
+  "job_id": "update.security"
 }
 ```
 
@@ -159,7 +165,7 @@ Trigger a job by ID.
 ```json
 {
   "status": "accepted",
-  "job_id": "update.run_full"
+  "job_id": "update.security"
 }
 ```
 
@@ -181,7 +187,7 @@ Trigger a job by ID.
 {
   "error": {
     "code": "job_not_found",
-    "message": "Job 'update.run_full' not found",
+    "message": "Job 'update.security' not found",
     "details": {}
   }
 }
@@ -189,9 +195,9 @@ Trigger a job by ID.
 
 ---
 
-## 3. Plugin endpoints
+## 5. Plugin Endpoints
 
-### 3.1. Mounting rules
+### 5.1. Mounting rules
 
 Each plugin is mounted under:
 
@@ -207,20 +213,22 @@ Example (update plugin):
 - `/api/v1/plugins/update/run`
 - `/api/v1/plugins/update/config`
 
-The exact schemas for each plugin live in the plugin's own `specs/API.md`.
+The exact schemas for each plugin live in the plugin's own `specs/SPEC.md`.
 
 ---
 
-## 4. Authentication (future)
+## 6. Authentication (Future)
 
 Initial version runs without auth on localhost only.
 
 Later, optional auth modes:
 
 - Shared token in header:
+
   ```text
   Authorization: Bearer <token>
   ```
+
 - Basic auth for simple setups.
 
 Details will be added as the security model evolves.

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Config Manager Core — Architecture
 
-## 1. Directory layout
+## 1. Directory Structure
 
 ```text
 config-manager-core/
@@ -34,37 +34,20 @@ config-manager-core/
 
 ---
 
-## 2. Core components
+## 2. Components
 
-### 2.1. Entry point (`cmd/cm/main.go`)
+### Entry point (`cmd/cm/main.go`)
 
 - Parses CLI flags (if any).
 - Loads configuration.
 - Initializes logging.
-- Initializes plugin registry (plugins self-register via `init()`).
+- Initializes plugin registry (core registers plugins explicitly in `main.go`).
 - Initializes scheduler and registers plugin jobs.
 - Starts HTTP API server in a background goroutine.
 - (Phase 2) Starts TUI (Bubble Tea) as the main loop.
 - (Phase 1) Blocks on signal (SIGINT/SIGTERM) until shutdown.
 
-### 2.2. Configuration (`internal/config/config.go`)
-
-- Go struct with YAML tags.
-- Sources (Phase 1):
-  - Config file (YAML, default `/etc/cm/config.yaml`).
-  - (Planned) Environment variables for overrides in a later phase.
-- Key settings (Phase 1 implementation):
-  - `listen_host`, `listen_port`
-  - `enabled_plugins` (optional, all enabled by default)
-  - `log_level`
-- Planned future settings:
-  - `auth_mode`, `auth_token`
-
----
-
-## 3. API layer
-
-### 3.1. Core routes (`internal/api/routes.go`)
+### Core routes (`internal/api/routes.go`)
 
 Implements:
 
@@ -75,18 +58,14 @@ Implements:
 - `GET /api/v1/jobs`
 - `POST /api/v1/jobs/trigger`
 
-### 3.2. Server (`internal/api/server.go`)
+### Server (`internal/api/server.go`)
 
 - Creates a Chi router.
 - Mounts core routes under `/api/v1`.
 - Mounts plugin routes under `/api/v1/plugins/{plugin_name}`.
 - Runs in a goroutine alongside the TUI.
 
----
-
-## 4. Plugin system
-
-### 4.1. Interface (`plugin/plugin.go`)
+### Plugin interface (`plugin/plugin.go`)
 
 Defines the `Plugin` interface:
 
@@ -100,9 +79,9 @@ type Plugin interface {
 }
 ```
 
-### 4.2. Registry (`plugin/registry.go`)
+### Plugin registry (`plugin/registry.go`)
 
-- Global registry populated by plugin `init()` functions.
+- Global registry populated by explicit `plugin.Register()` calls in `main.go`.
 - Provides:
   - `Register(p Plugin)`
   - `List() []Plugin`
@@ -110,11 +89,7 @@ type Plugin interface {
   - `AllRoutes() map[string]http.Handler`
   - `AllJobs() []JobDefinition`
 
----
-
-## 5. Scheduler
-
-### 5.1. Scheduler (`internal/scheduler/scheduler.go`)
+### Scheduler (`internal/scheduler/scheduler.go`)
 
 - Simple cron-based scheduler (internal implementation or third-party).
 - Registers jobs from plugins.
@@ -123,11 +98,7 @@ type Plugin interface {
   - `TriggerJob(id string) error`
 - Job IDs are globally unique: `{plugin_name}.{job_name}`.
 
----
-
-## 6. Logging
-
-### 6.1. Logging setup (`internal/logging/logging.go`)
+### Logging (`internal/logging/logging.go`)
 
 - Structured logging via `log/slog` (Go 1.21+ standard library).
 - Output to:
@@ -135,9 +106,20 @@ type Plugin interface {
   - Optional file.
 - Provides a standard logger for plugins: `slog.With("plugin", name)`.
 
+### Error handling
+
+- **Plugin registration:**
+  - Log error, skip faulty plugin.
+- **API errors:**
+  - Return structured JSON error responses (see API.md).
+- **Scheduler errors:**
+  - Log job failures with plugin and job ID.
+- **TUI errors:**
+  - Display error in TUI, allow retry or back navigation.
+
 ---
 
-## 7. Startup sequence
+## 3. Startup Sequence
 
 1. Parse CLI flags.
 2. Load configuration from YAML file.
@@ -148,18 +130,24 @@ type Plugin interface {
    - Mount core routes.
    - Mount plugin routes.
 7. Start HTTP server in a goroutine.
-8. Start TUI as the main blocking loop.
-9. On TUI exit, gracefully shut down HTTP server and scheduler.
+8. (Phase 2) Start TUI as the main blocking loop.
+9. On TUI exit (or SIGINT/SIGTERM in Phase 1), gracefully shut down HTTP server
+   and scheduler.
 
 ---
 
-## 8. Error handling
+## 4. Configuration
 
-- **Plugin registration:**
-  - Log error, skip faulty plugin.
-- **API errors:**
-  - Return structured JSON error responses (see API.md).
-- **Scheduler errors:**
-  - Log job failures with plugin and job ID.
-- **TUI errors:**
-  - Display error in TUI, allow retry or back navigation.
+Configuration is handled in `internal/config/config.go`:
+
+- Go struct with YAML tags.
+- Sources (Phase 1):
+  - Config file (YAML, default `/etc/cm/config.yaml`).
+  - Environment variables (`CM_LISTEN_HOST`, `CM_LISTEN_PORT`, `CM_LOG_LEVEL`,
+    `CM_ENABLED_PLUGINS`) override YAML values.
+- Key settings (Phase 1 implementation):
+  - `listen_host`, `listen_port`
+  - `enabled_plugins` (optional, all enabled by default)
+  - `log_level`
+- Planned future settings:
+  - `auth_mode`, `auth_token`

--- a/specs/PLUGIN-INTERFACE.md
+++ b/specs/PLUGIN-INTERFACE.md
@@ -7,44 +7,30 @@ networking). They are separate Go modules that:
 
 - Implement a common `Plugin` interface.
 - Are imported at build time into the core binary.
-- Self-register via Go `init()` functions.
+- Export a constructor (e.g., `NewUpdatePlugin()`) for explicit registration.
 - Provide HTTP handlers for API routes.
 - Optionally define scheduled jobs.
 
----
-
-## 2. Build-time registration
-
-In a plugin's Go module, a file (conventionally `register.go` or within
-`plugin.go`) calls the core registry during `init()`:
+In the plugin repo (e.g., `cm-plugin-update/plugin.go`), export a constructor:
 
 ```go
-package update
-
-import (
-    "github.com/msutara/config-manager-core/plugin"
-)
-
-func init() {
-    plugin.Register(&UpdatePlugin{})
+func NewUpdatePlugin() *UpdatePlugin {
+    return &UpdatePlugin{}
 }
 ```
 
-In the core binary's `cmd/cm/main.go`, plugins are imported with a blank
-identifier:
+In the core binary's `cmd/cm/main.go`, import the plugin and register it
+explicitly:
 
 ```go
-import (
-    _ "github.com/msutara/cm-plugin-update"
-    _ "github.com/msutara/cm-plugin-network"
-)
-```
+import update "github.com/msutara/cm-plugin-update"
 
-This triggers each plugin's `init()` function, registering it with the core.
+plugin.Register(update.NewUpdatePlugin())
+```
 
 ---
 
-## 3. Plugin interface
+## 2. Plugin Interface
 
 Defined in `plugin/plugin.go`:
 
@@ -71,7 +57,7 @@ type Plugin interface {
 
 ---
 
-## 4. Job definitions
+## 3. Job Definitions
 
 Plugins can define scheduled jobs via `ScheduledJobs()`:
 
@@ -91,7 +77,7 @@ Example:
 func (p *UpdatePlugin) ScheduledJobs() []JobDefinition {
     return []JobDefinition{
         {
-            ID:          "update.run_security",
+            ID:          "update.security",
             Description: "Run security updates",
             Cron:        "0 3 * * *",
             Func:        p.RunSecurityUpdates,
@@ -108,7 +94,7 @@ The core scheduler will:
 
 ---
 
-## 5. Route mounting
+## 4. Route Mounting
 
 CM Core will:
 
@@ -128,18 +114,7 @@ Example:
 
 ---
 
-## 6. Plugin metadata
-
-The `Name()`, `Version()`, and `Description()` methods provide metadata
-exposed via:
-
-- `GET /api/v1/plugins` — list all plugins.
-- `GET /api/v1/plugins/{name}` — get one plugin's metadata.
-- TUI menu generation — each plugin appears as a menu item.
-
----
-
-## 7. Configuration
+## 5. Configuration
 
 Plugin-specific configuration is managed by the plugin itself.
 Recommended pattern:
@@ -152,29 +127,10 @@ Recommended pattern:
 
 ---
 
-## 8. TUI integration
-
-Plugins may optionally implement a `TUIModel` interface (future) to provide
-custom Bubble Tea views. For Phase 1, the TUI will show plugin metadata
-and provide action triggers based on routes.
-
----
-
-## 9. Versioning
-
-Plugins should:
-
-- Expose a version string via `Version()`.
-- Follow semantic versioning where possible.
-- Be able to report their version via metadata and their own endpoints.
-
----
-
-## 10. Creating a new plugin
+## 6. Creating a Plugin
 
 1. Create a new Go module repo (e.g., `cm-plugin-foo`).
 2. Implement the `Plugin` interface.
-3. Call `plugin.Register()` in an `init()` function.
-4. In `config-manager-core/cmd/cm/main.go`, add:
-   `import _ "github.com/msutara/cm-plugin-foo"`
+3. Export a constructor function (e.g., `NewFooPlugin()`).
+4. Add import and `plugin.Register()` call to `cmd/cm/main.go`.
 5. Run `go mod tidy` and rebuild.

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -55,7 +55,7 @@ Those concerns are handled by plugins and external tools.
 
 ---
 
-## 4. High-level architecture
+## 4. Architecture
 
 - **Core binary:**
   - Go 1.22+
@@ -65,7 +65,7 @@ Those concerns are handled by plugins and external tools.
 - **Plugin system:**
   - Plugins are separate Go modules (separate repos).
   - Each plugin implements the `plugin.Plugin` interface.
-  - Plugins are imported at build time and register via `init()`.
+  - Plugins are imported at build time and registered explicitly in `main.go`.
   - Core mounts plugin routes under `/api/v1/plugins/{name}`.
 
 - **Scheduler:**
@@ -76,7 +76,7 @@ Those concerns are handled by plugins and external tools.
 
 ---
 
-## 5. Plugin model overview
+## 5. Plugin Model
 
 - Plugins are separate Go modules (often separate repos).
 - Each plugin:
@@ -89,7 +89,7 @@ Those concerns are handled by plugins and external tools.
 
 ---
 
-## 6. Frontend interaction model
+## 6. Frontend
 
 - **TUI frontend:**
   - Built with Bubble Tea (Charmbracelet).
@@ -104,17 +104,7 @@ Those concerns are handled by plugins and external tools.
 
 ---
 
-## 7. Security model
-
-- Default: listen on `localhost` only, no auth.
-- Configurable:
-  - Bind address and port.
-  - Simple auth (e.g., shared token or password) — future.
-  - HTTPS termination via reverse proxy — future.
-
----
-
-## 8. Deployment model
+## 7. Deployment
 
 - Built via `go build ./cmd/cm` → single binary `cm`.
 - Cross-compile: `GOOS=linux GOARCH=arm64 go build ./cmd/cm` for Raspbian.
@@ -124,12 +114,3 @@ Those concerns are handled by plugins and external tools.
 - Runs as a systemd service: `cm.service`.
 - Config file: `/etc/cm/config.yaml` (default path, configurable).
 - Logs: systemd journal and optional file logging.
-
----
-
-## 9. Future extensions
-
-- Web frontend (separate repo or embedded).
-- Multi-node awareness (optional).
-- Plugin marketplace/registry.
-- Advanced auth (mTLS, OAuth via reverse proxy).


### PR DESCRIPTION
Add markdownlint CI, unify documentation structure, fix markdown violations.

### Changes
- Add markdownlint CI job and .markdownlint.json config
- Unify SPEC.md, USAGE.md, copilot-instructions.md structure across repos
- Fix plugin registration docs (init() to explicit Register())
- Fix job IDs, Phase 2 annotations, broken LICENSE links
- Fix MD010/MD031/MD032/MD037/MD040/MD047 violations