### PR TITLE
fix: align code with explicit plugin registration docs

### DIFF
--- a/cmd/cm/main.go
+++ b/cmd/cm/main.go
@@ -18,11 +18,10 @@ import (
 	"github.com/msutara/config-manager-core/internal/logging"
 	"github.com/msutara/config-manager-core/internal/scheduler"
 	"github.com/msutara/config-manager-core/plugin"
-	// Import plugins here (build-time registration):
-	// _ "github.com/msutara/cm-plugin-update"
-	// _ "github.com/msutara/cm-plugin-network"
-	// Import TUI:
-	// _ "github.com/msutara/config-manager-tui"
+	// Plugins are registered explicitly below in main().
+	// Uncomment when plugin modules are added to go.mod:
+	// update "github.com/msutara/cm-plugin-update"
+	// network "github.com/msutara/cm-plugin-network"
 )
 
 var version = "0.1.0"
@@ -48,6 +47,11 @@ func main() {
 	logging.Setup(cfg.LogLevel)
 	api.Version = version
 	slog.Info("starting cm", "version", version)
+
+	// Register plugins explicitly.
+	// Uncomment when plugin modules are added to go.mod:
+	// plugin.Register(update.NewUpdatePlugin())
+	// plugin.Register(network.NewNetworkPlugin())
 
 	// Apply enabled_plugins filter from config
 	plugin.DisableExcept(cfg.EnabledPlugins)

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -13,9 +13,9 @@ var (
 	registry = make(map[string]Plugin)
 )
 
-// Register adds a plugin to the global registry. It is intended to be called
-// from a plugin's init() function. If a plugin with the same name is already
-// registered, the duplicate is logged and skipped.
+// Register adds a plugin to the global registry. It is called from the core
+// binary's main.go during startup (explicit registration). If a plugin with
+// the same name is already registered, the duplicate is logged and skipped.
 func Register(p Plugin) {
 	if p == nil {
 		slog.Warn("plugin registration skipped: nil plugin")


### PR DESCRIPTION
Align registry.go comment and main.go with the explicit plugin registration pattern documented in SPEC.md and PLUGIN-INTERFACE.md.

### Changes
- registry.go: update Register() comment from init() to main() calling pattern
- main.go: replace blank import comments with named imports + Register() calls (commented until plugin modules are wired in go.mod)