### PR TITLE
fix: correct license identifier in nfpm.yaml

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -9,7 +9,7 @@ version: "${VERSION}"
 maintainer: "msutara <msutara@users.noreply.github.com>"
 description: "Config Manager for headless Debian-based nodes"
 homepage: "https://github.com/msutara/config-manager-core"
-license: "MIT"
+license: "GPL-3.0"
 
 # Minimal dependencies — systemd for service management.
 depends:


### PR DESCRIPTION
The nfpm.yaml package metadata declared \license: MIT\ but the actual LICENSE file is GPL-3.0. Corrects the identifier so generated .deb packages carry the right license field.

Single metadata-only change — no code, no behavior change.