### PR TITLE
fix: correct softprops/action-gh-release SHA pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a1c98e14c581e82036f4 # v2.2.1
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: artifacts/*.deb
           generate_release_notes: true


### PR DESCRIPTION
Previous SHA was invalid. Pin to correct SHA for v2.2.1.