### PR TITLE
feat: change default port to 7788 and wire TUI to live API

### DIFF
--- a/cmd/cm/main.go
+++ b/cmd/cm/main.go
@@ -158,11 +158,17 @@ func main() {
 			})
 		}
 
+		// Use localhost for the TUI client URL when binding to all interfaces.
+		tuiHost := cfg.ListenHost
+		if tuiHost == "0.0.0.0" || tuiHost == "::" || tuiHost == "" {
+			tuiHost = "localhost"
+		}
+		apiURL := fmt.Sprintf("http://%s:%d", tuiHost, cfg.ListenPort)
 		slog.Info("starting TUI",
-			"api", fmt.Sprintf("http://%s:%d", cfg.ListenHost, cfg.ListenPort),
+			"api", apiURL,
 			"plugins", len(tuiPlugins),
 		)
-		model := tui.New(tuiPlugins)
+		model := tui.NewWithAPI(tuiPlugins, apiURL)
 		prog := tea.NewProgram(model, tea.WithAltScreen(), tea.WithoutSignalHandler())
 
 		// Monitor API server for fatal errors.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -20,7 +20,7 @@ Default path: `/etc/cm/config.yaml`
 
 ```yaml
 listen_host: localhost
-listen_port: 8080
+listen_port: 7788
 log_level: info
 enabled_plugins: []  # empty = all enabled
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/msutara/cm-plugin-network v0.0.0-20260226165526-2a54bb4473ff
 	github.com/msutara/cm-plugin-update v0.0.0-20260226165527-cb89018178f4
-	github.com/msutara/config-manager-tui v0.0.0-20260225012427-4c35766e6a6e
+	github.com/msutara/config-manager-tui v0.0.0-20260226192423-ceb5ad71765a
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/msutara/cm-plugin-update v0.0.0-20260226165527-cb89018178f4 h1:mDacon
 github.com/msutara/cm-plugin-update v0.0.0-20260226165527-cb89018178f4/go.mod h1:fBB8a1r8qL/0y4IIN/MPqN+4VJ3pJFJPNz/c9iF+Ppg=
 github.com/msutara/config-manager-tui v0.0.0-20260225012427-4c35766e6a6e h1:bTiOHie7Veu7gA59YiI8/veMEDeIYujfKhF4Tphg74E=
 github.com/msutara/config-manager-tui v0.0.0-20260225012427-4c35766e6a6e/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
+github.com/msutara/config-manager-tui v0.0.0-20260226192423-ceb5ad71765a h1:oGlvsO2o04Gnx8HMD9iKikkS4yH8SX7slwHL/fDruV8=
+github.com/msutara/config-manager-tui v0.0.0-20260226192423-ceb5ad71765a/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		ListenHost: "localhost",
-		ListenPort: 8080,
+		ListenPort: 7788,
 		LogLevel:   "info",
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,8 +11,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.ListenHost != "localhost" {
 		t.Fatalf("got host %q, want %q", cfg.ListenHost, "localhost")
 	}
-	if cfg.ListenPort != 8080 {
-		t.Fatalf("got port %d, want %d", cfg.ListenPort, 8080)
+	if cfg.ListenPort != 7788 {
+		t.Fatalf("got port %d, want %d", cfg.ListenPort, 7788)
 	}
 	if cfg.LogLevel != "info" {
 		t.Fatalf("got log_level %q, want %q", cfg.LogLevel, "info")
@@ -41,8 +41,8 @@ func TestLoadMissingFile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Should return defaults
-	if cfg.ListenPort != 8080 {
-		t.Fatalf("got port %d, want default 8080", cfg.ListenPort)
+	if cfg.ListenPort != 7788 {
+		t.Fatalf("got port %d, want default 7788", cfg.ListenPort)
 	}
 }
 
@@ -106,8 +106,8 @@ func TestLoadEmptyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.ListenPort != 8080 {
-		t.Fatalf("got port %d, want default 8080", cfg.ListenPort)
+	if cfg.ListenPort != 7788 {
+		t.Fatalf("got port %d, want default 7788", cfg.ListenPort)
 	}
 }
 
@@ -181,8 +181,8 @@ func TestApplyEnv_InvalidPort(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Should keep default when port is invalid
-	if cfg.ListenPort != 8080 {
-		t.Errorf("port: got %d, want default 8080", cfg.ListenPort)
+	if cfg.ListenPort != 7788 {
+		t.Errorf("port: got %d, want default 7788", cfg.ListenPort)
 	}
 }
 
@@ -197,8 +197,8 @@ func TestApplyEnv_OutOfRangePort(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cfg.ListenPort != 8080 {
-				t.Errorf("port %s: got %d, want default 8080", port, cfg.ListenPort)
+			if cfg.ListenPort != 7788 {
+				t.Errorf("port %s: got %d, want default 7788", port, cfg.ListenPort)
 			}
 		})
 	}

--- a/packaging/config.yaml
+++ b/packaging/config.yaml
@@ -11,7 +11,7 @@
 listen_host: "localhost"
 
 # Port for the REST API.
-listen_port: 8080
+listen_port: 7788
 
 # Log level: debug, info, warn, error
 log_level: "info"

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -99,7 +99,7 @@ Those concerns are handled by plugins and external tools.
 
 - **REST API:**
   - Runs embedded (separate goroutine) alongside the TUI.
-  - Listens on configurable port (default: `localhost:8080`).
+  - Listens on configurable port (default: `localhost:7788`).
   - Same plugin routes available to future web UI.
 
 ---


### PR DESCRIPTION
## Summary

Changes the default listen port from 8080 to 7788 and wires the TUI to the live API using `tui.NewWithAPI`.

## Changes

- **Port change**: Default `listen_port` from 8080 → 7788 (configurable via `CM_LISTEN_PORT` or `config.yaml`)
- **TUI API wiring**: Uses `tui.NewWithAPI(plugins, apiURL)` so TUI makes real HTTP calls to the running API
- **Bind address fix**: When `ListenHost` is `0.0.0.0`, `::`, or empty, the TUI client URL uses `localhost` instead (fixes Windows/cross-platform compatibility)
- **Docs/specs/tests**: All references updated to port 7788

## Testing

- All existing tests pass (`go test ./... -count=1`)
- Build succeeds on Windows (cross-compile for linux/arm verified in prior iterations)
- Fleet review (5 agents) confirmed clean except the bind-address bug (now fixed)

## Related

- Depends on [config-manager-tui v0.1.0](https://github.com/msutara/config-manager-tui) (merged PR #9)
