### PR TITLE
docs: add full uninstall instructions

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -142,6 +142,19 @@ sudo dpkg -r cm
 sudo dpkg --purge cm
 ```
 
+### Full uninstall
+
+To completely remove CM including all data, logs, user, and systemd overrides:
+
+```bash
+sudo systemctl stop cm.service
+sudo dpkg --purge cm
+sudo rm -rf /etc/cm /var/log/cm /var/lib/cm /etc/systemd/system/cm.service.d
+sudo userdel cm 2>/dev/null
+sudo groupdel cm 2>/dev/null
+sudo systemctl daemon-reload
+```
+
 ### Installed filesystem layout
 
 ```text


### PR DESCRIPTION
Adds a 'Full uninstall' section to USAGE.md documenting how to completely remove CM including data, logs, user/group, and systemd overrides.