### PR TITLE
feat: add Bearer token authentication

### DIFF
--- a/cmd/cm/main.go
+++ b/cmd/cm/main.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -14,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -33,15 +36,62 @@ import (
 // version is set at build time via -ldflags.
 var version = "dev"
 
+const defaultTokenPath = "/etc/cm/auth.token"
+
+// loadToken reads the auth token from the given file. Returns empty string
+// only when the file does not exist (auth disabled). Permission errors and
+// empty/whitespace-only files cause a fatal exit to prevent silently
+// disabling auth.
+func loadToken(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		fmt.Fprintf(os.Stderr, "fatal: cannot read auth token %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		fmt.Fprintf(os.Stderr, "fatal: auth token file %s is empty\n", path)
+		os.Exit(1)
+	}
+	return token
+}
+
+// generateToken writes a new random 32-byte hex token to the given file.
+func generateToken(path string) error {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Errorf("generate random bytes: %w", err)
+	}
+	token := hex.EncodeToString(b)
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write token file: %w", err)
+	}
+	return nil
+}
+
 func main() {
 	configPath := flag.String("config", "", "path to config file (default: /etc/cm/config.yaml)")
 	headless := flag.Bool("headless", false, "run without TUI (API server only, for systemd)")
 	connectURL := flag.String("connect", "", "connect TUI to running CM service at URL (skip local server)")
+	rotateToken := flag.Bool("rotate-token", false, "generate a new auth token and exit")
 	showVersion := flag.Bool("version", false, "show version and exit")
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Println("cm", version)
+		os.Exit(0)
+	}
+
+	if *rotateToken {
+		if err := generateToken(defaultTokenPath); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Token written to", defaultTokenPath)
+		fmt.Println("Restart the service to apply: sudo systemctl restart cm")
 		os.Exit(0)
 	}
 
@@ -112,12 +162,20 @@ func main() {
 		)
 	}
 
+	// Load auth token from file (empty = auth disabled).
+	authToken := loadToken(defaultTokenPath)
+	if authToken != "" {
+		slog.Info("bearer auth enabled", "token_file", defaultTokenPath)
+	} else {
+		slog.Info("bearer auth disabled (no token file)")
+	}
+
 	// Initialize scheduler
 	sched := scheduler.New()
 	sched.RegisterJobs(plugin.AllJobs())
 
 	// Create API server (not started yet — TUI mode probes first).
-	srv := api.NewServer(cfg.ListenHost, cfg.ListenPort, sched)
+	srv := api.NewServer(cfg.ListenHost, cfg.ListenPort, sched, authToken)
 
 	// Track whether a fatal error occurred.
 	var exitFailed atomic.Bool
@@ -212,7 +270,7 @@ func main() {
 			"plugins", len(tuiPlugins),
 			"mode", connMode,
 		)
-		model := tui.NewWithAPI(tuiPlugins, apiURL)
+		model := tui.NewWithAuth(tuiPlugins, apiURL, authToken)
 		model.SetConnectionMode(connMode)
 		prog := tea.NewProgram(model, tea.WithAltScreen(), tea.WithoutSignalHandler())
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,6 +9,7 @@ Options:
   --config PATH      Path to config file (default: /etc/cm/config.yaml)
   --headless         Run without TUI (API server only, for systemd)
   --connect URL      Connect TUI to running CM service (skip local server)
+  --rotate-token     Generate a new auth token and exit
   --version          Show version and exit
   -help, --help      Show help message
 ```
@@ -48,7 +49,47 @@ CM_ENABLED_PLUGINS=update ./cm
 Invalid `CM_LISTEN_PORT` values are ignored with a warning; the YAML or
 default value is kept.
 
-## 3. Building
+## 3. Authentication
+
+CM uses Bearer token authentication for API access. A random token is
+generated during package installation at `/etc/cm/auth.token` (mode 0600).
+
+All API endpoints require a valid token **except** `/api/v1/health`, which
+remains public for auto-detection probes.
+
+### How it works
+
+- The service reads the token file on startup. If the file exists but is
+  unreadable or empty, the service refuses to start (fail-closed).
+- The TUI reads the same file and attaches the token to every request
+  automatically — no user interaction needed. Run with `sudo cm` since
+  the token file is root-readable only.
+- External clients must include the header:
+
+```bash
+curl -H "Authorization: Bearer $(cat /etc/cm/auth.token)" \
+     http://localhost:7788/api/v1/node
+```
+
+### Rotating the token
+
+```bash
+# Generate a new token and restart the service
+sudo cm --rotate-token
+sudo systemctl restart cm
+```
+
+### Disabling auth
+
+If no token file exists, authentication is disabled and all endpoints are
+open. Remove the file and restart:
+
+```bash
+sudo rm /etc/cm/auth.token
+sudo systemctl restart cm
+```
+
+## 4. Building
 
 ```bash
 # Native build
@@ -71,7 +112,7 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o cm ./cmd/cm
 GOOS=linux GOARCH=arm64 go build -o cm ./cmd/cm
 ```
 
-## 4. Running
+## 5. Running
 
 ```bash
 # Run with defaults (standalone — starts own API server + TUI)
@@ -102,7 +143,7 @@ CM auto-detects whether a headless service is already running:
 Use `--connect URL` to override auto-detection and force client mode with an
 explicit service URL. Both modes can run side by side without crashing either.
 
-## 5. Deployment
+## 6. Deployment
 
 ### Quick install
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/msutara/cm-plugin-network v0.0.0-20260226165526-2a54bb4473ff
 	github.com/msutara/cm-plugin-update v0.0.0-20260226165527-cb89018178f4
-	github.com/msutara/config-manager-tui v0.0.0-20260226230509-d962af92522d
+	github.com/msutara/config-manager-tui v0.0.0-20260227160916-3dab97d327f1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,12 +28,8 @@ github.com/msutara/cm-plugin-network v0.0.0-20260226165526-2a54bb4473ff h1:fIUiB
 github.com/msutara/cm-plugin-network v0.0.0-20260226165526-2a54bb4473ff/go.mod h1:YIvMQTmg8XNTjx03sy0HDUhocAwBsQwF57HxVqkslfg=
 github.com/msutara/cm-plugin-update v0.0.0-20260226165527-cb89018178f4 h1:mDaconv8YshZIAV/xg+hqwELcx9XhQlQbBlx9Po+d1A=
 github.com/msutara/cm-plugin-update v0.0.0-20260226165527-cb89018178f4/go.mod h1:fBB8a1r8qL/0y4IIN/MPqN+4VJ3pJFJPNz/c9iF+Ppg=
-github.com/msutara/config-manager-tui v0.0.0-20260225012427-4c35766e6a6e h1:bTiOHie7Veu7gA59YiI8/veMEDeIYujfKhF4Tphg74E=
-github.com/msutara/config-manager-tui v0.0.0-20260225012427-4c35766e6a6e/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
-github.com/msutara/config-manager-tui v0.0.0-20260226192423-ceb5ad71765a h1:oGlvsO2o04Gnx8HMD9iKikkS4yH8SX7slwHL/fDruV8=
-github.com/msutara/config-manager-tui v0.0.0-20260226192423-ceb5ad71765a/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
-github.com/msutara/config-manager-tui v0.0.0-20260226230509-d962af92522d h1:3jvXQYQIjOrk5IIdAQNAHn3jgBvFNt64hBuOYFe50WQ=
-github.com/msutara/config-manager-tui v0.0.0-20260226230509-d962af92522d/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
+github.com/msutara/config-manager-tui v0.0.0-20260227160916-3dab97d327f1 h1:WSzUMiLaK2NOyaFITJutVl0EyD73FTa+l2yfAB+OQo8=
+github.com/msutara/config-manager-tui v0.0.0-20260227160916-3dab97d327f1/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// BearerAuth returns middleware that validates a Bearer token on every request.
+// When token is empty, all requests are allowed (auth disabled).
+func BearerAuth(token string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Auth disabled when no token configured.
+			if token == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				slog.Warn("auth: missing Authorization header", "path", r.URL.Path)
+				writeError(w, http.StatusUnauthorized, "unauthorized", "Authorization header required")
+				return
+			}
+
+			const prefix = "Bearer "
+			if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+				writeError(w, http.StatusUnauthorized, "unauthorized", "Bearer token required")
+				return
+			}
+
+			provided := auth[len(prefix):]
+			if provided == "" {
+				writeError(w, http.StatusUnauthorized, "unauthorized", "Bearer token cannot be empty")
+				return
+			}
+
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
+				slog.Warn("auth: invalid token", "path", r.URL.Path)
+				writeError(w, http.StatusForbidden, "forbidden", "Invalid token")
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBearerAuth_ValidTokenOnProtectedRoute(t *testing.T) {
+	// Health bypass is handled by Chi route groups (see TestNewServerAuthIntegration).
+	// This test verifies the middleware itself accepts valid tokens.
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
+	r.Header.Set("Authorization", "Bearer secret")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid token: got %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestBearerAuth_EmptyTokenDisablesAuth(t *testing.T) {
+	handler := BearerAuth("")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/plugins", nil)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("empty token: got %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestBearerAuth_MissingHeader(t *testing.T) {
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/plugins", nil)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing header: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBearerAuth_WrongScheme(t *testing.T) {
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/plugins", nil)
+	r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong scheme: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBearerAuth_InvalidToken(t *testing.T) {
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/plugins", nil)
+	r.Header.Set("Authorization", "Bearer wrong-token")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("invalid token: got %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestBearerAuth_ValidToken(t *testing.T) {
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/plugins", nil)
+	r.Header.Set("Authorization", "Bearer secret")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid token: got %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestBearerAuth_ConstantTimeComparison(t *testing.T) {
+	// Ensure a similar-but-wrong token is rejected.
+	handler := BearerAuth("abcdef123456")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
+	r.Header.Set("Authorization", "Bearer abcdef123457")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("similar token: got %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestBearerAuth_CaseInsensitiveScheme(t *testing.T) {
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
+	r.Header.Set("Authorization", "bearer secret")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("lowercase bearer: got %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestBearerAuth_EmptyBearerValue(t *testing.T) {
+	handler := BearerAuth("secret")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
+	r.Header.Set("Authorization", "Bearer ")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("empty bearer value: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -51,7 +51,7 @@ func TestHandleHealth(t *testing.T) {
 
 func TestHandleNode(t *testing.T) {
 	plugin.ResetForTesting()
-	srv := NewServer("localhost", 0, nil)
+	srv := NewServer("localhost", 0, nil, "")
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
 	srv.handleNode(w, r)
@@ -95,7 +95,7 @@ func TestHandleListPlugins(t *testing.T) {
 func TestHandleGetPluginNotFound(t *testing.T) {
 	plugin.ResetForTesting()
 
-	srv := NewServer("localhost", 0, nil)
+	srv := NewServer("localhost", 0, nil, "")
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/plugins/missing", nil)
 	srv.httpServer.Handler.ServeHTTP(w, r)
@@ -184,7 +184,7 @@ func TestNewServerIntegration(t *testing.T) {
 			return true
 		},
 	}
-	srv := NewServer("localhost", 0, sched)
+	srv := NewServer("localhost", 0, sched, "")
 	if srv == nil {
 		t.Fatal("NewServer returned nil")
 	}
@@ -196,6 +196,39 @@ func TestNewServerIntegration(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestNewServerAuthIntegration(t *testing.T) {
+	plugin.ResetForTesting()
+	srv := NewServer("localhost", 0, nil, "integ-secret")
+	if srv == nil {
+		t.Fatal("NewServer returned nil")
+	}
+
+	// Health should be accessible without token.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	srv.httpServer.Handler.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("health without token: got %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Node without token should be 401.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
+	srv.httpServer.Handler.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("node without token: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	// Node with valid token should be 200.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "/api/v1/node", nil)
+	r.Header.Set("Authorization", "Bearer integ-secret")
+	srv.httpServer.Handler.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("node with token: got %d, want %d", w.Code, http.StatusOK)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -48,28 +48,36 @@ func slogLogger(next http.Handler) http.Handler {
 }
 
 // NewServer creates a new API server with core and plugin routes mounted.
-func NewServer(host string, port int, sched JobTriggerer) *Server {
+// When authToken is non-empty, all endpoints except /api/v1/health require
+// a valid Bearer token.
+func NewServer(host string, port int, sched JobTriggerer, authToken string) *Server {
 	r := chi.NewRouter()
 	r.Use(slogLogger)
 	r.Use(middleware.Recoverer)
 
 	s := &Server{scheduler: sched, startTime: time.Now(), errCh: make(chan error, 1)}
 
-	// Core routes
-	r.Route("/api/v1", func(r chi.Router) {
-		r.Get("/health", handleHealth)
-		r.Get("/node", s.handleNode)
-		r.Get("/plugins", handleListPlugins)
-		r.Get("/plugins/{name}", handleGetPlugin)
-		r.Get("/jobs", handleListJobs)
-		r.Post("/jobs/trigger", s.handleTriggerJob)
-	})
+	// Health endpoint — public, no auth required (used for auto-detection).
+	r.Get("/api/v1/health", handleHealth)
 
-	// Plugin routes — compute handlers once, outside the registry lock.
-	pluginRoutes := plugin.AllRoutes()
-	for name, handler := range pluginRoutes {
-		r.Mount(fmt.Sprintf("/api/v1/plugins/%s", name), handler)
-	}
+	// All other routes require Bearer token (when configured).
+	r.Group(func(r chi.Router) {
+		r.Use(BearerAuth(authToken))
+
+		r.Route("/api/v1", func(r chi.Router) {
+			r.Get("/node", s.handleNode)
+			r.Get("/plugins", handleListPlugins)
+			r.Get("/plugins/{name}", handleGetPlugin)
+			r.Get("/jobs", handleListJobs)
+			r.Post("/jobs/trigger", s.handleTriggerJob)
+		})
+
+		// Plugin routes — compute handlers once, outside the registry lock.
+		pluginRoutes := plugin.AllRoutes()
+		for name, handler := range pluginRoutes {
+			r.Mount(fmt.Sprintf("/api/v1/plugins/%s", name), handler)
+		}
+	})
 
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", host, port),

--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -7,6 +7,16 @@ chmod 750 /var/log/cm /var/lib/cm
 
 case "$1" in
     configure)
+        # Generate auth token on fresh install (never overwrite existing).
+        if [ ! -f /etc/cm/auth.token ]; then
+            if command -v openssl >/dev/null 2>&1; then
+                (umask 077 && openssl rand -hex 32 > /etc/cm/auth.token)
+            else
+                (umask 077 && head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n' > /etc/cm/auth.token)
+            fi
+            echo "Auth token generated: /etc/cm/auth.token"
+        fi
+
         # Only run systemctl when systemd is the init system.
         if [ -d /run/systemd/system ]; then
             systemctl daemon-reload || true


### PR DESCRIPTION
## Summary

Adds Bearer token authentication to the CM Core API. All endpoints except `/api/v1/health` require a valid token.

## Design

- **Token lifecycle**: generated during `dpkg install` → stored at `/etc/cm/auth.token` (0600) → loaded at service startup → TUI auto-reads it
- **Health exempt**: `/api/v1/health` remains public for auto-detection probes (implemented via Chi route groups, not hardcoded path check)
- **Fail-closed**: permission errors or empty token file cause fatal exit (prevents silent auth bypass)
- **Rotation**: `sudo cm --rotate-token` + service restart

## Changes

| File | Description |
| --- | --- |
| `internal/api/auth.go` | BearerAuth middleware — constant-time comparison, case-insensitive scheme, empty-value rejection |
| `internal/api/auth_test.go` | 9 unit tests + edge cases (case-insensitive, empty bearer, constant-time) |
| `internal/api/server.go` | Chi route groups — health outside auth, everything else inside |
| `internal/api/routes_test.go` | Integration test: health bypass + 401/200 through full router |
| `cmd/cm/main.go` | loadToken, generateToken, --rotate-token flag |
| `packaging/postinst.sh` | Token generation with umask 077, openssl + /dev/urandom fallback |
| `docs/USAGE.md` | New Authentication section (#3) with usage examples |
| `go.mod` / `go.sum` | Updated TUI dependency for Bearer support |

## Testing

- 54 tests pass (9 new auth + 1 new integration + 44 existing)
- 2 rounds of fleet review (5 agents each, diverse models)
- Fleet findings addressed: umask race, openssl fallback, fail-closed semantics, Chi route groups, case-insensitive Bearer, empty-value guard, constructor dedup, restart warning

## Dependencies

- Requires [config-manager-tui#11](https://github.com/msutara/config-manager-tui/pull/11) (Bearer token in API client)
