### PR TITLE
ci: add GONOSUMCHECK/GONOSUMDB to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
           git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/msutara/".insteadOf "https://github.com/msutara/"
         env:
           GOPRIVATE: "github.com/msutara/*"
+          GONOSUMCHECK: "github.com/msutara/*"
+          GONOSUMDB: "github.com/msutara/*"
 
       - name: Build binary
         run: |
@@ -55,6 +57,8 @@ jobs:
             -o build/cm-linux-${{ matrix.binary_suffix }} ./cmd/cm
         env:
           GOPRIVATE: "github.com/msutara/*"
+          GONOSUMCHECK: "github.com/msutara/*"
+          GONOSUMDB: "github.com/msutara/*"
 
       - name: Install nfpm
         run: |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22
 	github.com/msutara/cm-plugin-update v0.0.0-20260228011010-b46ff863ba3b
 	github.com/msutara/config-manager-tui v0.0.0-20260228161435-5250ec6f17c0
-	github.com/msutara/config-manager-web v0.2.1
+	github.com/msutara/config-manager-web v0.0.0-20260228182935-5cc2c001b305
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/msutara/cm-plugin-update v0.0.0-20260228011010-b46ff863ba3b h1:KwSob0
 github.com/msutara/cm-plugin-update v0.0.0-20260228011010-b46ff863ba3b/go.mod h1:W1VGuNTzlaHoZ06nCtkVidh04NfvM8uuXjYeVeu0lhc=
 github.com/msutara/config-manager-tui v0.0.0-20260228161435-5250ec6f17c0 h1:oQRLSce40pc3KFRwNSli5KL3UXmIjrsSrM9SZ8mCu7A=
 github.com/msutara/config-manager-tui v0.0.0-20260228161435-5250ec6f17c0/go.mod h1:ZpNSCgpVxv72KkxiyYVciWsLZBRI/g98Qb/d4Nom6Z0=
-github.com/msutara/config-manager-web v0.2.1 h1:lBSTpSnkTN9f8MknWk6N4K37RwrlNBBbe/4zYLiyhI4=
-github.com/msutara/config-manager-web v0.2.1/go.mod h1:/dbgk2JKgqV7QH5mVd3s/qh/vtw1KpICnH7NnybF1lg=
+github.com/msutara/config-manager-web v0.0.0-20260228182935-5cc2c001b305 h1:BddGqTXhACouZqe6I/KvEMWuboj1ctAu+NYI4+r3AYA=
+github.com/msutara/config-manager-web v0.0.0-20260228182935-5cc2c001b305/go.mod h1:/dbgk2JKgqV7QH5mVd3s/qh/vtw1KpICnH7NnybF1lg=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=


### PR DESCRIPTION
Release CI failed with checksum mismatch on private modules. GOPRIVATE alone does not skip sum.golang.org verification — need GONOSUMCHECK and GONOSUMDB (already present in ci.yml, missing from release.yml).