### PR TITLE
feat: config plugin sections and Save()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -13,10 +15,82 @@ const defaultConfigPath = "/etc/cm/config.yaml"
 
 // Config holds the global configuration for CM Core.
 type Config struct {
-	ListenHost     string   `yaml:"listen_host"`
-	ListenPort     int      `yaml:"listen_port"`
-	EnabledPlugins []string `yaml:"enabled_plugins"` // empty = all enabled
-	LogLevel       string   `yaml:"log_level"`
+	ListenHost     string                    `yaml:"listen_host"`
+	ListenPort     int                       `yaml:"listen_port"`
+	EnabledPlugins []string                  `yaml:"enabled_plugins"` // empty = all enabled
+	LogLevel       string                    `yaml:"log_level"`
+	Plugins        map[string]map[string]any `yaml:"plugins,omitempty"`
+}
+
+// PluginConfig returns the config map for a specific plugin.
+// Returns nil if no config exists for that plugin.
+// NOTE: The returned map is a live reference to internal state.
+// Mutations are equivalent to calling SetPluginConfig.
+func (c *Config) PluginConfig(name string) map[string]any {
+	if c.Plugins == nil {
+		return nil
+	}
+	return c.Plugins[name]
+}
+
+// SetPluginConfig sets a single key in a plugin's config section.
+// Creates the plugin section if it doesn't exist.
+// NOTE: Config is not goroutine-safe. Callers must serialize access
+// when concurrent reads/writes are possible (e.g., from an API handler).
+func (c *Config) SetPluginConfig(plugin, key string, value any) {
+	if c.Plugins == nil {
+		c.Plugins = make(map[string]map[string]any)
+	}
+	if c.Plugins[plugin] == nil {
+		c.Plugins[plugin] = make(map[string]any)
+	}
+	c.Plugins[plugin][key] = value
+}
+
+// Save writes the config to a YAML file at the given path.
+// Uses atomic write (temp file + rename) to prevent corruption on crash.
+// TODO: Add path validation when Save is wired to an API endpoint.
+func (c *Config) Save(path string) error {
+	if path == "" {
+		path = defaultConfigPath
+	}
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".cm-config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write temp config: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("sync temp config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close temp config: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename config: %w", err)
+	}
+	return nil
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -238,5 +240,266 @@ func TestApplyEnv_PluginsWhitespaceOnlyPreservesYAML(t *testing.T) {
 	// Whitespace-only should be ignored, preserving YAML value
 	if len(cfg.EnabledPlugins) != 1 || cfg.EnabledPlugins[0] != "update" {
 		t.Errorf("enabled_plugins: got %v, want [update]", cfg.EnabledPlugins)
+	}
+}
+
+func TestPluginConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	// No plugins section — returns nil
+	if got := cfg.PluginConfig("update"); got != nil {
+		t.Fatalf("expected nil for missing plugin, got %v", got)
+	}
+
+	// Set a value
+	cfg.SetPluginConfig("update", "schedule", "0 3 * * *")
+	cfg.SetPluginConfig("update", "auto_security", true)
+
+	pc := cfg.PluginConfig("update")
+	if pc == nil {
+		t.Fatal("expected non-nil plugin config after SetPluginConfig")
+	}
+	if pc["schedule"] != "0 3 * * *" {
+		t.Errorf("schedule: got %v, want %q", pc["schedule"], "0 3 * * *")
+	}
+	if pc["auto_security"] != true {
+		t.Errorf("auto_security: got %v, want true", pc["auto_security"])
+	}
+
+	// Non-existent plugin still returns nil
+	if got := cfg.PluginConfig("network"); got != nil {
+		t.Fatalf("expected nil for network, got %v", got)
+	}
+}
+
+func TestLoadYAMLWithPluginSections(t *testing.T) {
+	clearCMEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	yamlData := `listen_host: "0.0.0.0"
+listen_port: 7788
+plugins:
+  update:
+    schedule: "0 5 * * *"
+    auto_security: true
+    security_source: "available"
+  network:
+    dns_override: "8.8.8.8"
+`
+	if err := os.WriteFile(path, []byte(yamlData), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	up := cfg.PluginConfig("update")
+	if up == nil {
+		t.Fatal("expected update plugin config")
+	}
+	if up["schedule"] != "0 5 * * *" {
+		t.Errorf("schedule: got %v, want %q", up["schedule"], "0 5 * * *")
+	}
+	if up["auto_security"] != true {
+		t.Errorf("auto_security: got %v, want true", up["auto_security"])
+	}
+	if up["security_source"] != "available" {
+		t.Errorf("security_source: got %v, want %q", up["security_source"], "available")
+	}
+
+	net := cfg.PluginConfig("network")
+	if net == nil {
+		t.Fatal("expected network plugin config")
+	}
+	if net["dns_override"] != "8.8.8.8" {
+		t.Errorf("dns_override: got %v, want %q", net["dns_override"], "8.8.8.8")
+	}
+}
+
+func TestSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.yaml")
+
+	cfg := DefaultConfig()
+	cfg.ListenHost = "0.0.0.0"
+	cfg.EnabledPlugins = []string{"update", "network"}
+	cfg.SetPluginConfig("update", "schedule", "0 3 * * *")
+	cfg.SetPluginConfig("update", "auto_security", true)
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify file exists and is readable
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read saved config: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("saved config is empty")
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	clearCMEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roundtrip.yaml")
+
+	original := DefaultConfig()
+	original.ListenHost = "0.0.0.0"
+	original.ListenPort = 9090
+	original.LogLevel = "debug"
+	original.EnabledPlugins = []string{"update"}
+	original.SetPluginConfig("update", "schedule", "0 5 * * *")
+	original.SetPluginConfig("update", "auto_security", true)
+	original.SetPluginConfig("update", "security_source", "available")
+
+	if err := original.Save(path); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.ListenHost != original.ListenHost {
+		t.Errorf("host: got %q, want %q", loaded.ListenHost, original.ListenHost)
+	}
+	if loaded.ListenPort != original.ListenPort {
+		t.Errorf("port: got %d, want %d", loaded.ListenPort, original.ListenPort)
+	}
+	if loaded.LogLevel != original.LogLevel {
+		t.Errorf("log_level: got %q, want %q", loaded.LogLevel, original.LogLevel)
+	}
+	if len(loaded.EnabledPlugins) != 1 || loaded.EnabledPlugins[0] != "update" {
+		t.Errorf("enabled_plugins: got %v, want [update]", loaded.EnabledPlugins)
+	}
+
+	up := loaded.PluginConfig("update")
+	if up == nil {
+		t.Fatal("expected update plugin config after round-trip")
+	}
+	if up["schedule"] != "0 5 * * *" {
+		t.Errorf("schedule: got %v, want %q", up["schedule"], "0 5 * * *")
+	}
+	if up["auto_security"] != true {
+		t.Errorf("auto_security: got %v, want true", up["auto_security"])
+	}
+	if up["security_source"] != "available" {
+		t.Errorf("security_source: got %v, want %q", up["security_source"], "available")
+	}
+}
+
+func TestSaveEmptyPath(t *testing.T) {
+	// Empty path falls back to defaultConfigPath (/etc/cm/config.yaml).
+	// Skip if that path is writable (e.g., root in CI container).
+	if _, err := os.Stat("/etc/cm"); err == nil {
+		t.Skip("default config directory exists; skipping to avoid side effects")
+	}
+	cfg := DefaultConfig()
+	err := cfg.Save("")
+	if err == nil {
+		t.Fatal("expected error writing to default path in test env")
+	}
+}
+
+func TestSaveBadPath(t *testing.T) {
+	cfg := DefaultConfig()
+	err := cfg.Save("/nonexistent/dir/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for bad path")
+	}
+}
+
+func TestSetPluginConfigOverwrite(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SetPluginConfig("update", "schedule", "0 3 * * *")
+	cfg.SetPluginConfig("update", "schedule", "0 5 * * *")
+
+	pc := cfg.PluginConfig("update")
+	if pc["schedule"] != "0 5 * * *" {
+		t.Errorf("schedule: got %v, want %q (overwritten value)", pc["schedule"], "0 5 * * *")
+	}
+}
+
+func TestSaveNilPlugins(t *testing.T) {
+	clearCMEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "noplugins.yaml")
+
+	cfg := DefaultConfig()
+	// Plugins is nil — omitempty should omit it from YAML
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if strings.Contains(string(data), "\nplugins:") {
+		t.Errorf("YAML should not contain 'plugins:' section when nil, got:\n%s", data)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.Plugins != nil {
+		t.Errorf("expected nil Plugins after round-trip, got %v", loaded.Plugins)
+	}
+}
+
+func TestSaveFilePermissions(t *testing.T) {
+	if os.Getenv("CI") != "" || runtime.GOOS == "windows" {
+		t.Skip("file permission test only reliable on local Linux/macOS")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perms.yaml")
+
+	cfg := DefaultConfig()
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("file permissions: got %o, want 0600", perm)
+	}
+}
+
+func TestSaveIntRoundTrip(t *testing.T) {
+	clearCMEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "types.yaml")
+
+	cfg := DefaultConfig()
+	cfg.SetPluginConfig("update", "retries", 5)
+	cfg.SetPluginConfig("update", "enabled", true)
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	up := loaded.PluginConfig("update")
+	// yaml.v3 preserves int (not float64) for integer values
+	if v, ok := up["retries"].(int); !ok || v != 5 {
+		t.Errorf("retries: got %v (%T), want 5 (int)", up["retries"], up["retries"])
+	}
+	if v, ok := up["enabled"].(bool); !ok || v != true {
+		t.Errorf("enabled: got %v (%T), want true (bool)", up["enabled"], up["enabled"])
 	}
 }


### PR DESCRIPTION
Adds plugin-specific config sections and Save() method for config persistence.

- \Plugins map[string]map[string]any\ field in Config struct
- \PluginConfig(name)\ / \SetPluginConfig(plugin, key, value)\ helpers
- \Save(path)\ writes config to YAML
- 7 new tests (round-trip, edge cases, error paths)

Closes #36