### PR TITLE
feat(scheduler): implement real cron scheduler with 5-field parser

### DIFF
--- a/internal/scheduler/cron.go
+++ b/internal/scheduler/cron.go
@@ -1,0 +1,207 @@
+package scheduler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cronSchedule holds parsed cron fields (minute, hour, dom, month, dow).
+type cronSchedule struct {
+	minute  [60]bool
+	hour    [24]bool
+	dom     [31]bool // 0-indexed: dom[0] = day 1
+	month   [12]bool // 0-indexed: month[0] = January
+	dow     [7]bool  // 0=Sunday
+	domStar bool     // true if DOM field was *
+	dowStar bool     // true if DOW field was *
+}
+
+// matches returns true if t falls within this schedule.
+// Standard cron semantics: when both DOM and DOW are restricted (not *),
+// the job fires if EITHER field matches.
+func (cs *cronSchedule) matches(t time.Time) bool {
+	if !cs.minute[t.Minute()] || !cs.hour[t.Hour()] || !cs.month[t.Month()-1] {
+		return false
+	}
+	domMatch := cs.dom[t.Day()-1]
+	dowMatch := cs.dow[t.Weekday()]
+	if cs.domStar || cs.dowStar {
+		return domMatch && dowMatch
+	}
+	return domMatch || dowMatch
+}
+
+// parseCron parses a standard 5-field cron expression.
+// Fields: minute(0-59) hour(0-23) dom(1-31) month(1-12) dow(0-7, 0 and 7 = Sunday)
+// Supports: * (wildcard), N (literal), N-M (range), N-M/S (stepped range), */S (stepped wildcard), N,M,... (list)
+func parseCron(expr string) (*cronSchedule, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("expected 5 fields, got %d", len(fields))
+	}
+
+	cs := &cronSchedule{}
+
+	if err := parseField(fields[0], cs.minute[:], 0, 59); err != nil {
+		return nil, fmt.Errorf("minute: %w", err)
+	}
+	if err := parseField(fields[1], cs.hour[:], 0, 23); err != nil {
+		return nil, fmt.Errorf("hour: %w", err)
+	}
+	cs.domStar = fields[2] == "*"
+	if err := parseField(fields[2], cs.dom[:], 1, 31); err != nil {
+		return nil, fmt.Errorf("dom: %w", err)
+	}
+	if err := parseField(fields[3], cs.month[:], 1, 12); err != nil {
+		return nil, fmt.Errorf("month: %w", err)
+	}
+	cs.dowStar = fields[4] == "*"
+	if err := parseDOWField(fields[4], cs.dow[:]); err != nil {
+		return nil, fmt.Errorf("dow: %w", err)
+	}
+
+	return cs, nil
+}
+
+// parseField parses a single cron field into a boolean slice.
+// offset adjusts for 1-based fields (dom, month): value - offset = slice index.
+func parseField(field string, bits []bool, min, max int) error {
+	offset := min
+	for _, part := range strings.Split(field, ",") {
+		if err := parsePart(part, bits, min, max, offset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parsePart(part string, bits []bool, min, max, offset int) error {
+	// Handle step: "X/S"
+	step := 1
+	if i := strings.Index(part, "/"); i >= 0 {
+		s, err := strconv.Atoi(part[i+1:])
+		if err != nil || s <= 0 {
+			return fmt.Errorf("invalid step %q", part[i+1:])
+		}
+		if s > max-min+1 {
+			return fmt.Errorf("step %d exceeds field range %d-%d", s, min, max)
+		}
+		step = s
+		part = part[:i]
+	}
+
+	var lo, hi int
+
+	switch {
+	case part == "*":
+		lo, hi = min, max
+	case strings.HasPrefix(part, "-"):
+		return fmt.Errorf("invalid value %q", part)
+	case strings.Contains(part, "-"):
+		rng := strings.SplitN(part, "-", 2)
+		var err error
+		lo, err = strconv.Atoi(rng[0])
+		if err != nil {
+			return fmt.Errorf("invalid range start %q", rng[0])
+		}
+		hi, err = strconv.Atoi(rng[1])
+		if err != nil {
+			return fmt.Errorf("invalid range end %q", rng[1])
+		}
+	default:
+		v, err := strconv.Atoi(part)
+		if err != nil {
+			return fmt.Errorf("invalid value %q", part)
+		}
+		lo = v
+		if step > 1 {
+			hi = max // "N/S" means "N-max/S"
+		} else {
+			hi = v
+		}
+	}
+
+	if lo < min || hi > max || lo > hi {
+		return fmt.Errorf("value %d-%d out of range %d-%d", lo, hi, min, max)
+	}
+
+	for v := lo; v <= hi; v += step {
+		bits[v-offset] = true
+	}
+	return nil
+}
+
+// parseDOWField handles the day-of-week field, normalizing 7 to 0 (Sunday).
+func parseDOWField(field string, bits []bool) error {
+	for _, part := range strings.Split(field, ",") {
+		if err := parseDOWPart(part, bits); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseDOWPart(part string, bits []bool) error {
+	step := 1
+	if i := strings.Index(part, "/"); i >= 0 {
+		s, err := strconv.Atoi(part[i+1:])
+		if err != nil || s <= 0 {
+			return fmt.Errorf("invalid step %q", part[i+1:])
+		}
+		if s > 7 {
+			return fmt.Errorf("step %d exceeds dow range", s)
+		}
+		step = s
+		part = part[:i]
+	}
+
+	var lo, hi int
+
+	switch {
+	case part == "*":
+		lo, hi = 0, 6
+	case strings.Contains(part, "-"):
+		rng := strings.SplitN(part, "-", 2)
+		var err error
+		lo, err = strconv.Atoi(rng[0])
+		if err != nil {
+			return fmt.Errorf("invalid range start %q", rng[0])
+		}
+		hi, err = strconv.Atoi(rng[1])
+		if err != nil {
+			return fmt.Errorf("invalid range end %q", rng[1])
+		}
+	default:
+		v, err := strconv.Atoi(part)
+		if err != nil {
+			return fmt.Errorf("invalid value %q", part)
+		}
+		if v == 7 {
+			v = 0 // normalize Sunday alias before range expansion
+		}
+		lo = v
+		if step > 1 {
+			hi = 6 // "N/S" means "N-6/S" (DOW logical range is 0-6)
+		} else {
+			hi = v
+		}
+	}
+
+	// Allow 0-7 (both 0 and 7 represent Sunday); validate bounds.
+	if lo < 0 || hi > 7 || lo > hi {
+		return fmt.Errorf("value %d-%d out of range 0-7", lo, hi)
+	}
+
+	// Iterate with 7→0 normalization inside the loop so stepped ranges
+	// only include Sunday when the step actually lands on 7.
+	for v := lo; v <= hi; v += step {
+		if v == 7 {
+			bits[0] = true
+		} else {
+			bits[v] = true
+		}
+	}
+	return nil
+}

--- a/internal/scheduler/cron_test.go
+++ b/internal/scheduler/cron_test.go
@@ -1,0 +1,288 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCron_Wildcard(t *testing.T) {
+	cs, err := parseCron("* * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should match any time
+	for i := 0; i < 60; i++ {
+		if !cs.minute[i] {
+			t.Errorf("minute[%d] should be true", i)
+		}
+	}
+}
+
+func TestParseCron_Specific(t *testing.T) {
+	cs, err := parseCron("30 3 15 6 2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cs.minute[30] {
+		t.Error("minute[30] should be true")
+	}
+	if cs.minute[0] {
+		t.Error("minute[0] should be false")
+	}
+	if !cs.hour[3] {
+		t.Error("hour[3] should be true")
+	}
+	if !cs.dom[14] { // day 15 → index 14
+		t.Error("dom[14] should be true")
+	}
+	if !cs.month[5] { // June → index 5
+		t.Error("month[5] should be true")
+	}
+	if !cs.dow[2] { // Tuesday
+		t.Error("dow[2] should be true")
+	}
+}
+
+func TestParseCron_Range(t *testing.T) {
+	cs, err := parseCron("0-5 * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i <= 5; i++ {
+		if !cs.minute[i] {
+			t.Errorf("minute[%d] should be true", i)
+		}
+	}
+	if cs.minute[6] {
+		t.Error("minute[6] should be false")
+	}
+}
+
+func TestParseCron_Step(t *testing.T) {
+	cs, err := parseCron("*/15 * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[int]bool{0: true, 15: true, 30: true, 45: true}
+	for i := 0; i < 60; i++ {
+		if cs.minute[i] != want[i] {
+			t.Errorf("minute[%d]: got %v, want %v", i, cs.minute[i], want[i])
+		}
+	}
+}
+
+func TestParseCron_List(t *testing.T) {
+	cs, err := parseCron("0 1,12,23 * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cs.hour[1] || !cs.hour[12] || !cs.hour[23] {
+		t.Error("hours 1, 12, 23 should be true")
+	}
+	if cs.hour[0] || cs.hour[2] {
+		t.Error("hours 0, 2 should be false")
+	}
+}
+
+func TestParseCron_DOWSunday7(t *testing.T) {
+	// 7 should be treated as Sunday (0) only
+	cs, err := parseCron("0 0 * * 7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cs.dow[0] {
+		t.Error("dow[0] (Sunday via 7) should be true")
+	}
+	// Must NOT match other days
+	for d := 1; d <= 6; d++ {
+		if cs.dow[d] {
+			t.Errorf("dow[%d] should be false for singleton 7", d)
+		}
+	}
+}
+
+func TestParseCron_Errors(t *testing.T) {
+	cases := []string{
+		"",
+		"* * *",
+		"* * * * * *",
+		"60 * * * *",
+		"-1 * * * *",
+		"* 24 * * *",
+		"* * 0 * *",
+		"* * 32 * *",
+		"* * * 0 *",
+		"* * * 13 *",
+		"abc * * * *",
+		"*/0 * * * *",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := parseCron(c); err == nil {
+				t.Errorf("expected error for %q", c)
+			}
+		})
+	}
+}
+
+func TestCronSchedule_Matches(t *testing.T) {
+	// "0 3 * * *" = every day at 03:00
+	cs, err := parseCron("0 3 * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	match := time.Date(2026, 3, 1, 3, 0, 0, 0, time.UTC)
+	if !cs.matches(match) {
+		t.Error("should match 2026-03-01 03:00")
+	}
+
+	noMatch := time.Date(2026, 3, 1, 3, 1, 0, 0, time.UTC)
+	if cs.matches(noMatch) {
+		t.Error("should not match 2026-03-01 03:01")
+	}
+}
+
+func TestParseCron_RangeWithStep(t *testing.T) {
+	cs, err := parseCron("1-30/10 * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[int]bool{1: true, 11: true, 21: true}
+	for i := 0; i < 60; i++ {
+		if cs.minute[i] != want[i] {
+			t.Errorf("minute[%d]: got %v, want %v", i, cs.minute[i], want[i])
+		}
+	}
+}
+
+func TestParseCron_DOWRange7(t *testing.T) {
+	// "5-7" should match Fri(5), Sat(6), Sun(0)
+	cs, err := parseCron("0 0 * * 5-7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cs.dow[5] {
+		t.Error("dow[5] (Friday) should be true")
+	}
+	if !cs.dow[6] {
+		t.Error("dow[6] (Saturday) should be true")
+	}
+	if !cs.dow[0] {
+		t.Error("dow[0] (Sunday via 7) should be true")
+	}
+}
+
+func TestParseCron_DOWFullRange07(t *testing.T) {
+	// "0-7" should match all days
+	cs, err := parseCron("0 0 * * 0-7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for d := 0; d <= 6; d++ {
+		if !cs.dow[d] {
+			t.Errorf("dow[%d] should be true for 0-7", d)
+		}
+	}
+}
+
+func TestParseCron_DOMDOWOrSemantics(t *testing.T) {
+	// "0 0 1 * 1" = 1st of month OR every Monday
+	cs, err := parseCron("0 0 1 * 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Monday March 2, 2026 — not 1st but Monday → should match
+	mon := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	if !cs.matches(mon) {
+		t.Error("should match Monday (DOW=1) even though DOM!=1")
+	}
+
+	// Sunday March 1, 2026 — 1st but not Monday → should match
+	first := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	if !cs.matches(first) {
+		t.Error("should match 1st of month even though DOW!=1")
+	}
+
+	// Wednesday March 4, 2026 — neither 1st nor Monday → should NOT match
+	wed := time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC)
+	if cs.matches(wed) {
+		t.Error("should not match when neither DOM nor DOW matches")
+	}
+}
+
+func TestParseCron_StepOverflow(t *testing.T) {
+	// Step larger than field range should be rejected
+	_, err := parseCron("1-59/9999999999 * * * *")
+	if err == nil {
+		t.Error("expected error for excessive step value")
+	}
+}
+
+func TestParseCron_StepOnLiteral(t *testing.T) {
+	// "5/10" in minutes = starting at 5, every 10 → {5, 15, 25, 35, 45, 55}
+	cs, err := parseCron("5/10 * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[int]bool{5: true, 15: true, 25: true, 35: true, 45: true, 55: true}
+	for m := 0; m < 60; m++ {
+		if want[m] && !cs.minute[m] {
+			t.Errorf("minute %d should be set", m)
+		}
+		if !want[m] && cs.minute[m] {
+			t.Errorf("minute %d should not be set", m)
+		}
+	}
+}
+
+func TestParseCron_StepOnLiteralDOW(t *testing.T) {
+	// "1/2" in DOW = starting at Mon(1), every 2 through 6 → {1, 3, 5}
+	cs, err := parseCron("0 0 * * 1/2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should match Mon(1), Wed(3), Fri(5) — NOT Sunday
+	want := [7]bool{false, true, false, true, false, true, false}
+	for d := 0; d < 7; d++ {
+		if cs.dow[d] != want[d] {
+			t.Errorf("dow[%d]: got %v, want %v", d, cs.dow[d], want[d])
+		}
+	}
+}
+
+func TestParseCron_StepOnLiteralDOWSunday7(t *testing.T) {
+	// "7/2" in DOW = Sunday(7→0), every 2 through 6 → {0, 2, 4, 6}
+	cs, err := parseCron("0 0 * * 7/2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [7]bool{true, false, true, false, true, false, true}
+	for d := 0; d < 7; d++ {
+		if cs.dow[d] != want[d] {
+			t.Errorf("dow[%d]: got %v, want %v", d, cs.dow[d], want[d])
+		}
+	}
+}
+
+func TestParseCron_DOMUnrestrictedWithRestrictedDOW(t *testing.T) {
+	// "0 0 1-31 * 1" — DOM syntactically restricted but covers all days.
+	// Per cron semantics both fields are restricted → OR semantics apply.
+	cs, err := parseCron("0 0 1-31 * 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Tuesday March 3, 2026 — DOM=3 matches, DOW=2 doesn't → OR fires
+	tue := time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC)
+	if !cs.matches(tue) {
+		t.Error("should match any day via DOM=1-31 OR semantics")
+	}
+
+	// Monday March 2, 2026 — both DOM and DOW match
+	mon := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	if !cs.matches(mon) {
+		t.Error("should match Monday as well")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,18 +1,23 @@
 package scheduler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/msutara/config-manager-core/plugin"
 )
 
 // Scheduler manages recurring jobs defined by plugins.
+// It is not goroutine-safe for Start/Stop — call them from the main goroutine.
 type Scheduler struct {
-	mu   sync.RWMutex
-	jobs map[string]plugin.JobDefinition
+	mu     sync.RWMutex
+	jobs   map[string]plugin.JobDefinition
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 // New creates a new Scheduler.
@@ -35,6 +40,12 @@ func (s *Scheduler) RegisterJobs(jobs []plugin.JobDefinition) {
 		if _, exists := s.jobs[j.ID]; exists {
 			slog.Warn("duplicate job ID; registration skipped", "job_id", j.ID, "cron", j.Cron)
 			continue
+		}
+		if j.Cron != "" {
+			if _, err := parseCron(j.Cron); err != nil {
+				slog.Warn("job registration skipped: invalid cron", "job_id", j.ID, "cron", j.Cron, "error", err)
+				continue
+			}
 		}
 		s.jobs[j.ID] = j
 		slog.Info("job registered", "job_id", j.ID, "cron", j.Cron)
@@ -78,14 +89,110 @@ func (s *Scheduler) JobExists(id string) bool {
 	return ok
 }
 
-// Start begins the cron scheduler. Placeholder for Phase 2.
+// Start begins the cron scheduler. Jobs are evaluated every minute.
+// Call from the main goroutine only; calling Start twice without Stop is a no-op.
 func (s *Scheduler) Start() {
-	slog.Info("scheduler started (cron not yet implemented)")
+	if s.cancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.done = make(chan struct{})
+
+	go s.run(ctx)
+	slog.Info("scheduler started")
 }
 
-// Stop gracefully stops the scheduler.
+// Stop gracefully stops the scheduler and waits for the run loop to exit.
 func (s *Scheduler) Stop() {
-	slog.Info("scheduler stopped")
+	if s.cancel != nil {
+		s.cancel()
+		<-s.done
+		s.cancel = nil
+		slog.Info("scheduler stopped")
+	}
+}
+
+// Reschedule updates a job's cron expression. Pass an empty string to disable.
+func (s *Scheduler) Reschedule(id, cron string) error {
+	if cron != "" {
+		if _, err := parseCron(cron); err != nil {
+			return fmt.Errorf("invalid cron %q: %w", cron, err)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	j, ok := s.jobs[id]
+	if !ok {
+		return ErrJobNotFound
+	}
+	j.Cron = cron
+	s.jobs[id] = j
+	slog.Info("job rescheduled", "job_id", id, "cron", cron)
+	return nil
+}
+
+func (s *Scheduler) run(ctx context.Context) {
+	defer close(s.done)
+
+	// Align to the start of the next minute for predictable firing.
+	now := time.Now()
+	next := now.Truncate(time.Minute).Add(time.Minute)
+	alignTimer := time.NewTimer(time.Until(next))
+	defer alignTimer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-alignTimer.C:
+	}
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	s.tick(time.Now())
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-ticker.C:
+			s.tick(t)
+		}
+	}
+}
+
+// tick fires all jobs whose cron expression matches the given time.
+// TODO: add per-job overlap protection (skip if previous instance still running).
+func (s *Scheduler) tick(t time.Time) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, j := range s.jobs {
+		if j.Cron == "" || j.Func == nil {
+			continue
+		}
+		sched, err := parseCron(j.Cron)
+		if err != nil {
+			slog.Warn("bad cron expression", "job_id", j.ID, "cron", j.Cron, "error", err)
+			continue
+		}
+		if sched.matches(t) {
+			job := j // capture for goroutine
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("job panicked", "job_id", job.ID, "panic", r)
+					}
+				}()
+				slog.Info("cron firing job", "job_id", job.ID)
+				if err := job.Func(); err != nil {
+					slog.Error("job failed", "job_id", job.ID, "error", err)
+				}
+			}()
+		}
+	}
 }
 
 // ErrJobNotFound is returned when a job ID is not in the registry.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/msutara/config-manager-core/plugin"
 )
@@ -118,5 +120,248 @@ func TestJobExists(t *testing.T) {
 	}
 	if s.JobExists("") {
 		t.Fatal("expected JobExists to return false for empty ID")
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	s := New()
+	s.Start()
+	s.Stop()
+	// Double stop should not panic
+	s.Stop()
+}
+
+func TestTickFiresJob(t *testing.T) {
+	s := New()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	s.RegisterJobs([]plugin.JobDefinition{
+		{
+			ID:   "test.tick",
+			Cron: "* * * * *",
+			Func: func() error {
+				wg.Done()
+				return nil
+			},
+		},
+	})
+
+	s.tick(time.Now())
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for job to fire")
+	}
+}
+
+func TestTickSkipsNonMatching(t *testing.T) {
+	s := New()
+
+	fired := make(chan struct{}, 1)
+	s.RegisterJobs([]plugin.JobDefinition{
+		{
+			ID:   "test.nomatch",
+			Cron: "0 3 * * *",
+			Func: func() error {
+				fired <- struct{}{}
+				return nil
+			},
+		},
+	})
+
+	// 12:30 doesn't match "0 3 * * *"
+	noon := time.Date(2026, 3, 1, 12, 30, 0, 0, time.UTC)
+	s.tick(noon)
+
+	select {
+	case <-fired:
+		t.Error("job should not have fired for non-matching time")
+	case <-time.After(50 * time.Millisecond):
+		// expected: no fire
+	}
+}
+
+func TestTickSkipsNilFunc(t *testing.T) {
+	s := New()
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.nilfunc2", Cron: "* * * * *", Func: nil},
+	})
+	// Should not panic
+	s.tick(time.Now())
+}
+
+func TestTickSkipsEmptyCron(t *testing.T) {
+	s := New()
+
+	fired := make(chan struct{}, 1)
+	s.RegisterJobs([]plugin.JobDefinition{
+		{
+			ID:   "test.nocron",
+			Cron: "",
+			Func: func() error {
+				fired <- struct{}{}
+				return nil
+			},
+		},
+	})
+
+	s.tick(time.Now())
+
+	select {
+	case <-fired:
+		t.Error("job should not have fired with empty cron")
+	case <-time.After(50 * time.Millisecond):
+		// expected: no fire
+	}
+}
+
+func TestTickJobError(t *testing.T) {
+	s := New()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	s.RegisterJobs([]plugin.JobDefinition{
+		{
+			ID:   "test.err",
+			Cron: "* * * * *",
+			Func: func() error {
+				defer wg.Done()
+				return errors.New("boom")
+			},
+		},
+	})
+
+	s.tick(time.Now())
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+		// Error was logged; job completed without panic
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for error job")
+	}
+}
+
+func TestTickInvalidCron(t *testing.T) {
+	s := New()
+
+	// Bypass validation by directly inserting an invalid cron
+	s.mu.Lock()
+	s.jobs["test.badcron"] = plugin.JobDefinition{
+		ID:   "test.badcron",
+		Cron: "not valid",
+		Func: func() error { return nil },
+	}
+	s.mu.Unlock()
+
+	// Should not panic
+	s.tick(time.Now())
+}
+
+func TestDoubleStartIsNoop(t *testing.T) {
+	s := New()
+	s.Start()
+	s.Start() // should be no-op
+	s.Stop()
+	// If double-start leaked, this would hang
+}
+
+func TestReschedule(t *testing.T) {
+	s := New()
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.resched", Cron: "0 3 * * *", Func: func() error { return nil }},
+	})
+
+	if err := s.Reschedule("test.resched", "* * * * *"); err != nil {
+		t.Fatalf("Reschedule failed: %v", err)
+	}
+
+	s.mu.RLock()
+	j := s.jobs["test.resched"]
+	s.mu.RUnlock()
+	if j.Cron != "* * * * *" {
+		t.Errorf("cron: got %q, want %q", j.Cron, "* * * * *")
+	}
+}
+
+func TestReschedule_NotFound(t *testing.T) {
+	s := New()
+	err := s.Reschedule("nonexistent", "* * * * *")
+	if !errors.Is(err, ErrJobNotFound) {
+		t.Errorf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestReschedule_InvalidCron(t *testing.T) {
+	s := New()
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.bad", Cron: "0 3 * * *", Func: func() error { return nil }},
+	})
+
+	err := s.Reschedule("test.bad", "not a cron")
+	if err == nil {
+		t.Fatal("expected error for invalid cron")
+	}
+}
+
+func TestReschedule_EmptyDisables(t *testing.T) {
+	s := New()
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.disable", Cron: "0 3 * * *", Func: func() error { return nil }},
+	})
+
+	if err := s.Reschedule("test.disable", ""); err != nil {
+		t.Fatalf("Reschedule to empty should succeed: %v", err)
+	}
+
+	s.mu.RLock()
+	j := s.jobs["test.disable"]
+	s.mu.RUnlock()
+	if j.Cron != "" {
+		t.Errorf("cron: got %q, want empty", j.Cron)
+	}
+}
+
+func TestTickJobPanicRecovery(t *testing.T) {
+	s := New()
+
+	done := make(chan struct{})
+	s.RegisterJobs([]plugin.JobDefinition{
+		{
+			ID:   "test.panic",
+			Cron: "* * * * *",
+			Func: func() error {
+				defer func() { close(done) }()
+				panic("boom")
+			},
+		},
+	})
+
+	// Should not crash the process
+	s.tick(time.Now())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for panicking job")
+	}
+}
+
+func TestRegisterJobsInvalidCron(t *testing.T) {
+	s := New()
+
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.badcron", Cron: "not valid", Func: func() error { return nil }},
+	})
+
+	if s.JobExists("test.badcron") {
+		t.Error("job with invalid cron should not be registered")
 	}
 }


### PR DESCRIPTION
## Summary

Replace placeholder Start/Stop with real cron-based scheduler implementing 5-field cron expression parsing.

### Changes

**scheduler.go** — Real scheduler lifecycle:
- \Start()\/\Stop()\ with context and graceful shutdown via \done\ channel
- Minute-aligned tick loop evaluating jobs against cron expressions
- \Reschedule(id, cron)\ to update job schedules at runtime
- Double-Start guard prevents goroutine leaks

**cron.go** — 5-field cron expression parser:
- Standard fields: \minute(0-59) hour(0-23) dom(1-31) month(1-12) dow(0-7)\
- Supports: wildcards (\*\), ranges (\N-M\), steps (\*/S\, \N-M/S\), lists (\N,M\)
- DOW 7 normalized to Sunday (0) for both singletons and ranges
- DOM/DOW OR semantics per \crontab(5)\ when both fields are restricted
- Step overflow guard prevents integer overflow

### Tests (31 scheduler + 14 cron parser)

- Start/Stop lifecycle, double-Start no-op
- Tick: fire matching, skip non-matching/nil/empty, error handling, invalid cron
- Reschedule: valid, not found, invalid cron
- Cron: wildcards, specific values, ranges, steps, lists, DOW Sunday-as-7, DOW ranges, DOM/DOW OR semantics, step overflow, error cases

### Fleet Review

10-agent review (Architect, Correctness, Security, Test Coverage, Operational, Deep Security, Unicode, Test Quality, Lint, Contract) + targeted 4-agent re-review. All findings addressed.

Closes #37