### PR TITLE
deps: bump cm-plugin-update to 430e75b (Configurable interface)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22
-	github.com/msutara/cm-plugin-update v0.0.0-20260228011010-b46ff863ba3b
+	github.com/msutara/cm-plugin-update v0.0.0-20260301015807-430e75b6c4d7
 	github.com/msutara/config-manager-tui v0.0.0-20260301061458-e4d8f37bc7c0
 	github.com/msutara/config-manager-web v0.0.0-20260301215045-6d63afe55ea7
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22 h1:7BkzV
 github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22/go.mod h1:gH2489bbikv5S0Vhbo6IMh7e6LjzzOhEfu5ctXdqkmQ=
 github.com/msutara/cm-plugin-update v0.0.0-20260228011010-b46ff863ba3b h1:KwSob0J4Mq0wEtaR/mxdQ8KyvvcTjQjkNbz8aU+rVhA=
 github.com/msutara/cm-plugin-update v0.0.0-20260228011010-b46ff863ba3b/go.mod h1:W1VGuNTzlaHoZ06nCtkVidh04NfvM8uuXjYeVeu0lhc=
+github.com/msutara/cm-plugin-update v0.0.0-20260301015807-430e75b6c4d7 h1:eLlQgOtmcN2HnBd4DK0ahyRrrxtoI4nsUI92JjonvE4=
+github.com/msutara/cm-plugin-update v0.0.0-20260301015807-430e75b6c4d7/go.mod h1:y3NsGDXlRm9AOOtDWnYcEzpb+NBiTjVkh2c3iuzGwz0=
 github.com/msutara/config-manager-tui v0.0.0-20260301061458-e4d8f37bc7c0 h1:GWuQfTNKaeogpOpoSNCrmD821wx9Vk/4SymXoY06Xvs=
 github.com/msutara/config-manager-tui v0.0.0-20260301061458-e4d8f37bc7c0/go.mod h1:exrc96eIdQVjO0AQybrTIa3bxXX7w3j997remQXOKr4=
 github.com/msutara/config-manager-web v0.0.0-20260301141540-50670f54f597 h1:0Qb2PqVuhZKpqIbKmw32WLrS4N3HU67a6qfVwLlgC2I=


### PR DESCRIPTION
Bump cm-plugin-update to 430e75b which implements the Configurable interface.

Without this, the deployed v0.3.1 binary returns 501 on /settings because the update plugin does not satisfy plugin.Configurable — breaking both TUI settings and web UI config display.

Dep-only change, no code modifications.
