### PR TITLE
feat: async job tracking + API hardening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22
 	github.com/msutara/cm-plugin-update v0.0.0-20260301015807-430e75b6c4d7
-	github.com/msutara/config-manager-tui v0.0.0-20260301061458-e4d8f37bc7c0
+	github.com/msutara/config-manager-tui v0.0.0-20260302024853-d8757a656a3b
 	github.com/msutara/config-manager-web v0.0.0-20260301215045-6d63afe55ea7
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/msutara/cm-plugin-update v0.0.0-20260301015807-430e75b6c4d7 h1:eLlQgO
 github.com/msutara/cm-plugin-update v0.0.0-20260301015807-430e75b6c4d7/go.mod h1:y3NsGDXlRm9AOOtDWnYcEzpb+NBiTjVkh2c3iuzGwz0=
 github.com/msutara/config-manager-tui v0.0.0-20260301061458-e4d8f37bc7c0 h1:GWuQfTNKaeogpOpoSNCrmD821wx9Vk/4SymXoY06Xvs=
 github.com/msutara/config-manager-tui v0.0.0-20260301061458-e4d8f37bc7c0/go.mod h1:exrc96eIdQVjO0AQybrTIa3bxXX7w3j997remQXOKr4=
+github.com/msutara/config-manager-tui v0.0.0-20260302024853-d8757a656a3b h1:b57T6N/0k015om8iBsyMZA/XSkmWPLdVfBt6bypX5RE=
+github.com/msutara/config-manager-tui v0.0.0-20260302024853-d8757a656a3b/go.mod h1:exrc96eIdQVjO0AQybrTIa3bxXX7w3j997remQXOKr4=
 github.com/msutara/config-manager-web v0.0.0-20260301141540-50670f54f597 h1:0Qb2PqVuhZKpqIbKmw32WLrS4N3HU67a6qfVwLlgC2I=
 github.com/msutara/config-manager-web v0.0.0-20260301141540-50670f54f597/go.mod h1:/dbgk2JKgqV7QH5mVd3s/qh/vtw1KpICnH7NnybF1lg=
 github.com/msutara/config-manager-web v0.0.0-20260301215045-6d63afe55ea7 h1:7shWvrhhKNLFqPyAbsJVGy6PZtCut0O8WQxVGbRt4no=

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"net/http"
@@ -167,8 +169,25 @@ func (s *Server) handleTriggerJob(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		JobID string `json:"job_id"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body")
+	r.Body = http.MaxBytesReader(w, r.Body, maxTriggerBody)
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request body too large")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body")
+		}
+		return
+	}
+	// Reject trailing data so MaxBytesReader cannot be bypassed.
+	if err := dec.Decode(&json.RawMessage{}); err != io.EOF {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request body too large")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Request body must contain exactly one JSON object")
+		}
 		return
 	}
 
@@ -188,22 +207,47 @@ func (s *Server) handleTriggerJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jid := req.JobID
-	go func() {
-		if err := s.scheduler.TriggerJob(jid); err != nil {
-			slog.Error("triggered job failed", "job_id", jid, "error", err)
-		} else {
-			slog.Info("triggered job completed", "job_id", jid)
-		}
-	}()
+	if err := s.scheduler.TriggerJobAsync(req.JobID); err != nil {
+		slog.Error("failed to trigger job", "job_id", req.JobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "trigger_failed",
+			"Failed to trigger job; see server logs")
+		return
+	}
 	writeJSON(w, http.StatusAccepted, map[string]string{
 		"status": "accepted",
 		"job_id": req.JobID,
 	})
 }
 
+func (s *Server) handleGetLatestRun(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if s.scheduler == nil {
+		writeError(w, http.StatusInternalServerError, "scheduler_unavailable", "Scheduler not configured")
+		return
+	}
+	if !s.scheduler.JobExists(id) {
+		writeError(w, http.StatusNotFound, "job_not_found",
+			"Job '"+id+"' not found")
+		return
+	}
+	run := s.scheduler.LatestRun(id)
+	if run == nil {
+		writeError(w, http.StatusNotFound, "no_runs", "No runs recorded for job '"+id+"'")
+		return
+	}
+	// Sanitize the error field to avoid leaking internal details from plugin jobs.
+	sanitized := *run
+	if sanitized.Error != "" {
+		sanitized.Error = "job failed; see server logs"
+	}
+	writeJSON(w, http.StatusOK, &sanitized)
+}
+
 // maxConfigBody is the maximum request body for config updates (64 KB).
 const maxConfigBody = 64 << 10
+
+// maxTriggerBody is the maximum request body for job trigger requests (1 KB).
+const maxTriggerBody = 1 << 10
 
 // getConfigurablePlugin resolves a plugin by name and asserts it implements
 // Configurable. Returns the Configurable and true on success; writes an
@@ -274,8 +318,24 @@ func (s *Server) updatePluginConfig(w http.ResponseWriter, r *http.Request, name
 		Key   string `json:"key"`
 		Value any    `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body")
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request body too large")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body")
+		}
+		return
+	}
+	// Reject trailing data so MaxBytesReader cannot be bypassed.
+	if err := dec.Decode(&json.RawMessage{}); err != io.EOF {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request body too large")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Request body must contain exactly one JSON object")
+		}
 		return
 	}
 	if req.Key == "" {
@@ -286,8 +346,10 @@ func (s *Server) updatePluginConfig(w http.ResponseWriter, r *http.Request, name
 	// Validate that schedule values are strings before accepting.
 	if req.Key == "schedule" {
 		if _, ok := req.Value.(string); !ok {
+			slog.Warn("schedule value type mismatch",
+				"plugin", name, "type", fmt.Sprintf("%T", req.Value))
 			writeError(w, http.StatusBadRequest, "invalid_config",
-				"schedule value must be a string")
+				"Invalid configuration value; see server logs for details")
 			return
 		}
 	}
@@ -304,7 +366,10 @@ func (s *Server) updatePluginConfig(w http.ResponseWriter, r *http.Request, name
 			writeError(w, http.StatusInternalServerError, "save_failed",
 				"Config applied but failed to persist; see server logs for details")
 		} else {
-			writeError(w, http.StatusBadRequest, "invalid_config", err.Error())
+			slog.Warn("plugin config validation failed",
+				"plugin", name, "key", req.Key, "error", err)
+			writeError(w, http.StatusBadRequest, "invalid_config",
+				"Invalid configuration value; see server logs for details")
 		}
 		return
 	}

--- a/internal/api/routes_test.go
+++ b/internal/api/routes_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,19 +12,29 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/msutara/config-manager-core/internal/scheduler"
 	"github.com/msutara/config-manager-core/plugin"
 )
 
 // mockScheduler implements JobTriggerer for testing.
 type mockScheduler struct {
-	triggerFunc    func(id string) error
-	existsFunc     func(id string) bool
-	rescheduleFunc func(id, cron string) error
+	triggerFunc      func(id string) error
+	triggerAsyncFunc func(id string) error
+	existsFunc       func(id string) bool
+	rescheduleFunc   func(id, cron string) error
+	latestRunFunc    func(id string) *scheduler.JobRun
 }
 
 func (m *mockScheduler) TriggerJob(id string) error {
 	if m.triggerFunc != nil {
 		return m.triggerFunc(id)
+	}
+	return nil
+}
+
+func (m *mockScheduler) TriggerJobAsync(id string) error {
+	if m.triggerAsyncFunc != nil {
+		return m.triggerAsyncFunc(id)
 	}
 	return nil
 }
@@ -38,6 +49,13 @@ func (m *mockScheduler) JobExists(id string) bool {
 func (m *mockScheduler) Reschedule(id, cron string) error {
 	if m.rescheduleFunc != nil {
 		return m.rescheduleFunc(id, cron)
+	}
+	return nil
+}
+
+func (m *mockScheduler) LatestRun(id string) *scheduler.JobRun {
+	if m.latestRunFunc != nil {
+		return m.latestRunFunc(id)
 	}
 	return nil
 }
@@ -387,6 +405,35 @@ func TestHandleTriggerJobEmptyID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("got status %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleTriggerJob_TrailingGarbage(t *testing.T) {
+	sched := &mockScheduler{}
+	srv := &Server{scheduler: sched}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs/trigger",
+		bytes.NewBufferString(`{"job_id":"test"}GARBAGE`))
+	srv.handleTriggerJob(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("exactly one JSON object")) {
+		t.Errorf("expected trailing-data error message, got: %s", w.Body.String())
+	}
+}
+
+func TestHandleTriggerJob_TrailingSecondObject(t *testing.T) {
+	sched := &mockScheduler{}
+	srv := &Server{scheduler: sched}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs/trigger",
+		bytes.NewBufferString(`{"job_id":"test"}{"extra":true}`))
+	srv.handleTriggerJob(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400; body: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -880,6 +927,43 @@ func TestHandleUpdatePluginConfig_BodyTooLarge(t *testing.T) {
 		bytes.NewBufferString(body))
 	srv.httpServer.Handler.ServeHTTP(w, r)
 
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want 413; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdatePluginConfig_TrailingGarbage(t *testing.T) {
+	plugin.ResetForTesting()
+	mp := &mockConfigPlugin{}
+	mp.Configure(nil)
+	plugin.Register(mp)
+
+	srv := NewServer("localhost", 0, &mockScheduler{}, &mockConfigProvider{}, "", nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/plugins/mockconfig/settings",
+		bytes.NewBufferString(`{"key":"schedule","value":"0 4 * * *"}GARBAGE`))
+	srv.httpServer.Handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("exactly one JSON object")) {
+		t.Errorf("expected trailing-data error message, got: %s", w.Body.String())
+	}
+}
+
+func TestHandleUpdatePluginConfig_TrailingSecondObject(t *testing.T) {
+	plugin.ResetForTesting()
+	mp := &mockConfigPlugin{}
+	mp.Configure(nil)
+	plugin.Register(mp)
+
+	srv := NewServer("localhost", 0, &mockScheduler{}, &mockConfigProvider{}, "", nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/plugins/mockconfig/settings",
+		bytes.NewBufferString(`{"key":"schedule","value":"0 4 * * *"}{"extra":true}`))
+	srv.httpServer.Handler.ServeHTTP(w, r)
+
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("got %d, want 400; body: %s", w.Code, w.Body.String())
 	}
@@ -981,5 +1065,311 @@ func TestSettingsRouteWithPluginMount_PluginRouteStillWorks(t *testing.T) {
 	}
 	if w.Body.String() != `{"status":"ok"}` {
 		t.Errorf("body: got %q, want %q", w.Body.String(), `{"status":"ok"}`)
+	}
+}
+
+func TestHandleGetLatestRun_Completed(t *testing.T) {
+	now := time.Now()
+	end := now.Add(5 * time.Second)
+	sched := &mockScheduler{
+		latestRunFunc: func(id string) *scheduler.JobRun {
+			return &scheduler.JobRun{
+				JobID:     id,
+				Status:    "completed",
+				StartedAt: now,
+				EndedAt:   &end,
+				Duration:  "5s",
+			}
+		},
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/update.full/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "update.full")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var body scheduler.JobRun
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "completed" {
+		t.Errorf("status: got %q, want completed", body.Status)
+	}
+	if body.Duration != "5s" {
+		t.Errorf("duration: got %q, want 5s", body.Duration)
+	}
+}
+
+func TestHandleGetLatestRun_NotFound(t *testing.T) {
+	sched := &mockScheduler{
+		latestRunFunc: func(_ string) *scheduler.JobRun { return nil },
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/missing/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "missing")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetLatestRun_Running(t *testing.T) {
+	now := time.Now()
+	sched := &mockScheduler{
+		latestRunFunc: func(id string) *scheduler.JobRun {
+			return &scheduler.JobRun{
+				JobID:     id,
+				Status:    "running",
+				StartedAt: now,
+			}
+		},
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/update.full/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "update.full")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var body scheduler.JobRun
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "running" {
+		t.Errorf("status: got %q, want running", body.Status)
+	}
+	if body.EndedAt != nil {
+		t.Errorf("ended_at should be nil for running job")
+	}
+}
+
+func TestHandleGetLatestRun_NoScheduler(t *testing.T) {
+	srv := &Server{scheduler: nil}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/any/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "any")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleTriggerJob_UsesAsync(t *testing.T) {
+	var asyncCalled bool
+	sched := &mockScheduler{
+		triggerAsyncFunc: func(_ string) error {
+			asyncCalled = true
+			return nil
+		},
+	}
+	srv := &Server{scheduler: sched}
+
+	payload := `{"job_id":"test.job"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs/trigger",
+		bytes.NewBufferString(payload))
+	srv.handleTriggerJob(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("got %d, want 202; body: %s", w.Code, w.Body.String())
+	}
+	if !asyncCalled {
+		t.Error("expected TriggerJobAsync to be called")
+	}
+}
+
+func TestHandleTriggerJob_AsyncFailure(t *testing.T) {
+	sched := &mockScheduler{
+		triggerAsyncFunc: func(_ string) error {
+			return errors.New("job func is nil")
+		},
+	}
+	srv := &Server{scheduler: sched}
+
+	payload := `{"job_id":"broken.job"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/jobs/trigger",
+		bytes.NewBufferString(payload))
+	srv.handleTriggerJob(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %v", resp)
+	}
+	if errObj["code"] != "trigger_failed" {
+		t.Errorf("error code: got %q, want trigger_failed", errObj["code"])
+	}
+}
+
+func TestHandleGetLatestRun_JobNotFound(t *testing.T) {
+	sched := &mockScheduler{
+		existsFunc: func(_ string) bool { return false },
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/missing/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "missing")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %v", resp)
+	}
+	if errObj["code"] != "job_not_found" {
+		t.Errorf("error code: got %q, want job_not_found", errObj["code"])
+	}
+}
+
+func TestHandleGetLatestRun_NoRunsShape(t *testing.T) {
+	sched := &mockScheduler{
+		existsFunc:    func(_ string) bool { return true },
+		latestRunFunc: func(_ string) *scheduler.JobRun { return nil },
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/test/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "test")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %v", resp)
+	}
+	if errObj["code"] != "no_runs" {
+		t.Errorf("error code: got %q, want no_runs", errObj["code"])
+	}
+}
+
+func TestHandleGetLatestRun_CompletedShape(t *testing.T) {
+	now := time.Now()
+	end := now.Add(2 * time.Second)
+	sched := &mockScheduler{
+		existsFunc: func(_ string) bool { return true },
+		latestRunFunc: func(_ string) *scheduler.JobRun {
+			return &scheduler.JobRun{
+				JobID:     "test.job",
+				Status:    "completed",
+				StartedAt: now,
+				EndedAt:   &end,
+				Duration:  "2s",
+			}
+		},
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/test.job/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "test.job")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["job_id"] != "test.job" {
+		t.Errorf("job_id: got %v, want test.job", resp["job_id"])
+	}
+	if resp["status"] != "completed" {
+		t.Errorf("status: got %v, want completed", resp["status"])
+	}
+	if resp["duration"] != "2s" {
+		t.Errorf("duration: got %v, want 2s", resp["duration"])
+	}
+}
+
+func TestHandleGetLatestRun_ErrorSanitized(t *testing.T) {
+	now := time.Now()
+	end := now.Add(time.Second)
+	sched := &mockScheduler{
+		existsFunc: func(_ string) bool { return true },
+		latestRunFunc: func(_ string) *scheduler.JobRun {
+			return &scheduler.JobRun{
+				JobID:     "test.job",
+				Status:    "failed",
+				StartedAt: now,
+				EndedAt:   &end,
+				Error:     "secret internal detail: /etc/apt/sources.list",
+				Duration:  "1s",
+			}
+		},
+	}
+	srv := &Server{scheduler: sched}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/jobs/test.job/runs/latest", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "test.job")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	srv.handleGetLatestRun(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "job failed; see server logs" {
+		t.Errorf("error should be sanitized, got %q", resp["error"])
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/msutara/config-manager-core/internal/scheduler"
 	"github.com/msutara/config-manager-core/plugin"
 )
 
@@ -31,8 +32,10 @@ func (s *Server) Err() <-chan error {
 // JobTriggerer is satisfied by the scheduler to trigger jobs by ID.
 type JobTriggerer interface {
 	TriggerJob(id string) error
+	TriggerJobAsync(id string) error
 	JobExists(id string) bool
 	Reschedule(id, cron string) error
+	LatestRun(id string) *scheduler.JobRun
 }
 
 // ConfigProvider abstracts config persistence so the API can update
@@ -86,6 +89,7 @@ func NewServer(host string, port int, sched JobTriggerer, cfg ConfigProvider, au
 			r.Put("/plugins/{name}/settings", s.handleUpdatePluginConfig)
 			r.Get("/jobs", handleListJobs)
 			r.Post("/jobs/trigger", s.handleTriggerJob)
+			r.Get("/jobs/{id}/runs/latest", s.handleGetLatestRun)
 		})
 
 		// Plugin routes — compute handlers once, outside the registry lock.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,19 +11,31 @@ import (
 	"github.com/msutara/config-manager-core/plugin"
 )
 
+// JobRun records the outcome of a single job execution.
+type JobRun struct {
+	JobID     string     `json:"job_id"`
+	Status    string     `json:"status"` // "running", "completed", "failed"
+	StartedAt time.Time  `json:"started_at"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+	Error     string     `json:"error,omitempty"`
+	Duration  string     `json:"duration,omitempty"`
+}
+
 // Scheduler manages recurring jobs defined by plugins.
 // It is not goroutine-safe for Start/Stop — call them from the main goroutine.
 type Scheduler struct {
-	mu     sync.RWMutex
-	jobs   map[string]plugin.JobDefinition
-	cancel context.CancelFunc
-	done   chan struct{}
+	mu       sync.RWMutex
+	jobs     map[string]plugin.JobDefinition
+	lastRuns map[string]*JobRun
+	cancel   context.CancelFunc
+	done     chan struct{}
 }
 
 // New creates a new Scheduler.
 func New() *Scheduler {
 	return &Scheduler{
-		jobs: make(map[string]plugin.JobDefinition),
+		jobs:     make(map[string]plugin.JobDefinition),
+		lastRuns: make(map[string]*JobRun),
 	}
 }
 
@@ -64,7 +76,8 @@ func (s *Scheduler) ListJobs() []plugin.JobDefinition {
 	return jobs
 }
 
-// TriggerJob runs a job by ID immediately.
+// TriggerJob runs a job by ID immediately and returns its error (if any).
+// It does not track the run in lastRuns — use TriggerJobAsync for tracking.
 func (s *Scheduler) TriggerJob(id string) error {
 	s.mu.RLock()
 	j, ok := s.jobs[id]
@@ -79,6 +92,82 @@ func (s *Scheduler) TriggerJob(id string) error {
 		return fmt.Errorf("job %q has no function defined", id)
 	}
 	return j.Func()
+}
+
+// TriggerJobAsync starts a job in a background goroutine and tracks its
+// execution status. The caller can poll LatestRun to monitor progress.
+func (s *Scheduler) TriggerJobAsync(id string) error {
+	s.mu.RLock()
+	j, ok := s.jobs[id]
+	s.mu.RUnlock()
+
+	if !ok {
+		return ErrJobNotFound
+	}
+	if j.Func == nil {
+		return fmt.Errorf("job %q has no function defined", id)
+	}
+
+	now := time.Now()
+	run := &JobRun{
+		JobID:     id,
+		Status:    "running",
+		StartedAt: now,
+	}
+	s.mu.Lock()
+	s.lastRuns[id] = run
+	s.mu.Unlock()
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("job panicked", "job_id", id, "panic", r)
+				end := time.Now()
+				s.finalizeRun(run, "failed", fmt.Sprintf("panic: %v", r), end)
+			}
+		}()
+		slog.Info("async job started", "job_id", id)
+		err := j.Func()
+		end := time.Now()
+		if err != nil {
+			s.finalizeRun(run, "failed", err.Error(), end)
+			slog.Error("async job failed", "job_id", id, "error", err)
+		} else {
+			s.finalizeRun(run, "completed", "", end)
+			slog.Info("async job completed", "job_id", id, "duration", run.Duration)
+		}
+	}()
+	return nil
+}
+
+// finalizeRun updates a run record under the scheduler lock. Using a
+// dedicated helper with a deferred unlock ensures the lock is always
+// released even if finalizeRun itself panics.
+func (s *Scheduler) finalizeRun(run *JobRun, status, errMsg string, end time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run.Status = status
+	run.EndedAt = &end
+	run.Error = errMsg
+	run.Duration = end.Sub(run.StartedAt).Round(time.Millisecond).String()
+}
+
+// LatestRun returns the most recent run record for a job, or nil if none.
+func (s *Scheduler) LatestRun(id string) *JobRun {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	run, ok := s.lastRuns[id]
+	if !ok {
+		return nil
+	}
+	// Return a deep copy so callers don't race with in-flight updates.
+	cp := *run
+	// Deep-copy pointer fields so callers cannot mutate scheduler internals.
+	if cp.EndedAt != nil {
+		endedAtCopy := *cp.EndedAt
+		cp.EndedAt = &endedAtCopy
+	}
+	return &cp
 }
 
 // JobExists returns true if a job with the given ID is registered.
@@ -167,8 +256,7 @@ func (s *Scheduler) run(ctx context.Context) {
 // TODO: add per-job overlap protection (skip if previous instance still running).
 func (s *Scheduler) tick(t time.Time) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+	snapshot := make([]plugin.JobDefinition, 0)
 	for _, j := range s.jobs {
 		if j.Cron == "" || j.Func == nil {
 			continue
@@ -179,19 +267,41 @@ func (s *Scheduler) tick(t time.Time) {
 			continue
 		}
 		if sched.matches(t) {
-			job := j // capture for goroutine
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("job panicked", "job_id", job.ID, "panic", r)
-					}
-				}()
-				slog.Info("cron firing job", "job_id", job.ID)
-				if err := job.Func(); err != nil {
-					slog.Error("job failed", "job_id", job.ID, "error", err)
+			snapshot = append(snapshot, j)
+		}
+	}
+	s.mu.RUnlock()
+
+	for _, job := range snapshot {
+		j := job // capture for goroutine
+		now := time.Now()
+		run := &JobRun{
+			JobID:     j.ID,
+			Status:    "running",
+			StartedAt: now,
+		}
+		s.mu.Lock()
+		s.lastRuns[j.ID] = run
+		s.mu.Unlock()
+
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("job panicked", "job_id", j.ID, "panic", r)
+					end := time.Now()
+					s.finalizeRun(run, "failed", fmt.Sprintf("panic: %v", r), end)
 				}
 			}()
-		}
+			slog.Info("cron firing job", "job_id", j.ID)
+			err := j.Func()
+			end := time.Now()
+			if err != nil {
+				s.finalizeRun(run, "failed", err.Error(), end)
+				slog.Error("job failed", "job_id", j.ID, "error", err)
+			} else {
+				s.finalizeRun(run, "completed", "", end)
+			}
+		}()
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -364,4 +365,198 @@ func TestRegisterJobsInvalidCron(t *testing.T) {
 	if s.JobExists("test.badcron") {
 		t.Error("job with invalid cron should not be registered")
 	}
+}
+
+func TestTriggerJobAsync_Success(t *testing.T) {
+	s := New()
+	barrier := make(chan struct{}) // blocks job until test checks "running"
+	done := make(chan struct{})
+
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.async", Cron: "* * * * *", Func: func() error {
+			<-barrier // wait for test to assert "running"
+			close(done)
+			return nil
+		}},
+	})
+
+	if err := s.TriggerJobAsync("test.async"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be running immediately (job is blocked on barrier)
+	run := s.LatestRun("test.async")
+	if run == nil {
+		t.Fatal("expected a run record")
+	}
+	if run.Status != "running" {
+		t.Errorf("status: got %q, want running", run.Status)
+	}
+
+	close(barrier) // unblock the job
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async job")
+	}
+
+	waitForRunStatus(t, s, "test.async", "completed", 2*time.Second)
+
+	run = s.LatestRun("test.async")
+	if run.Status != "completed" {
+		t.Errorf("status after completion: got %q, want completed", run.Status)
+	}
+	if run.EndedAt == nil {
+		t.Error("ended_at should be set after completion")
+	}
+	if run.Duration == "" {
+		t.Error("duration should be set after completion")
+	}
+}
+
+func TestTriggerJobAsync_Failure(t *testing.T) {
+	s := New()
+	done := make(chan struct{})
+
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.fail", Func: func() error {
+			defer close(done)
+			return errors.New("boom")
+		}},
+	})
+
+	if err := s.TriggerJobAsync("test.fail"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	waitForRunStatus(t, s, "test.fail", "failed", 2*time.Second)
+
+	run := s.LatestRun("test.fail")
+	if run.Status != "failed" {
+		t.Errorf("status: got %q, want failed", run.Status)
+	}
+	if run.Error != "boom" {
+		t.Errorf("error: got %q, want boom", run.Error)
+	}
+}
+
+func TestTriggerJobAsync_Panic(t *testing.T) {
+	s := New()
+	done := make(chan struct{})
+
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.panic2", Func: func() error {
+			defer close(done)
+			panic("kaboom")
+		}},
+	})
+
+	if err := s.TriggerJobAsync("test.panic2"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	waitForRunStatus(t, s, "test.panic2", "failed", 2*time.Second)
+
+	run := s.LatestRun("test.panic2")
+	if run.Status != "failed" {
+		t.Errorf("status: got %q, want failed", run.Status)
+	}
+	if run.Error == "" {
+		t.Error("error should describe the panic")
+	}
+}
+
+func TestTriggerJobAsync_NotFound(t *testing.T) {
+	s := New()
+	err := s.TriggerJobAsync("missing")
+	if !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("got %v, want ErrJobNotFound", err)
+	}
+}
+
+func TestTriggerJobAsync_NilFunc(t *testing.T) {
+	s := New()
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.nilfunc", Func: nil},
+	})
+	err := s.TriggerJobAsync("test.nilfunc")
+	if err == nil {
+		t.Fatal("expected error for nil func")
+	}
+	if !strings.Contains(err.Error(), "no function defined") {
+		t.Errorf("error should mention 'no function defined', got: %v", err)
+	}
+}
+
+func TestLatestRun_NoRuns(t *testing.T) {
+	s := New()
+	s.RegisterJobs([]plugin.JobDefinition{
+		{ID: "test.noruns"},
+	})
+	run := s.LatestRun("test.noruns")
+	if run != nil {
+		t.Errorf("expected nil, got %+v", run)
+	}
+}
+
+func TestTickTracksRuns(t *testing.T) {
+	s := New()
+	done := make(chan struct{})
+
+	s.RegisterJobs([]plugin.JobDefinition{
+		{
+			ID:   "test.tickrun",
+			Cron: "* * * * *",
+			Func: func() error {
+				close(done)
+				return nil
+			},
+		},
+	})
+
+	s.tick(time.Now())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	waitForRunStatus(t, s, "test.tickrun", "completed", 2*time.Second)
+
+	run := s.LatestRun("test.tickrun")
+	if run == nil {
+		t.Fatal("expected tick to record a run")
+	}
+	if run.Status != "completed" {
+		t.Errorf("status: got %q, want completed", run.Status)
+	}
+}
+
+// waitForRunStatus polls LatestRun until the run reaches the expected status
+// or the timeout expires. This avoids timing-sensitive sleeps.
+func waitForRunStatus(t *testing.T, s *Scheduler, jobID, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		run := s.LatestRun(jobID)
+		if run != nil && run.Status == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for job %q to reach status %q", jobID, want)
 }

--- a/specs/API.md
+++ b/specs/API.md
@@ -220,13 +220,73 @@ scheduler job `{name}.security` is rescheduled using the new value.
 
 The `warning` field is included only when non-empty (e.g. scheduler update failed).
 
+**Response 400** (invalid JSON body):
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "Invalid JSON body",
+    "details": {}
+  }
+}
+```
+
+**Response 400** (trailing data):
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "Request body must contain exactly one JSON object",
+    "details": {}
+  }
+}
+```
+
+**Response 400** (missing key):
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "key is required",
+    "details": {}
+  }
+}
+```
+
 **Response 400** (invalid key / value):
 
 ```json
 {
   "error": {
     "code": "invalid_config",
-    "message": "unknown config key: bad_key",
+    "message": "Invalid configuration value; see server logs for details",
+    "details": {}
+  }
+}
+```
+
+**Response 413** (request body too large):
+
+```json
+{
+  "error": {
+    "code": "request_too_large",
+    "message": "Request body too large",
+    "details": {}
+  }
+}
+```
+
+**Response 500** (persistence failure):
+
+```json
+{
+  "error": {
+    "code": "save_failed",
+    "message": "Config applied but failed to persist; see server logs for details",
     "details": {}
   }
 }
@@ -285,7 +345,31 @@ Trigger a job by ID.
 }
 ```
 
-**Response 400:**
+**Response 400** (invalid JSON):
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "Invalid JSON body",
+    "details": {}
+  }
+}
+```
+
+**Response 400** (trailing data):
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "Request body must contain exactly one JSON object",
+    "details": {}
+  }
+}
+```
+
+**Response 400** (missing job_id):
 
 ```json
 {
@@ -304,6 +388,111 @@ Trigger a job by ID.
   "error": {
     "code": "job_not_found",
     "message": "Job 'update.security' not found",
+    "details": {}
+  }
+}
+```
+
+**Response 413** (request body too large):
+
+```json
+{
+  "error": {
+    "code": "request_too_large",
+    "message": "Request body too large",
+    "details": {}
+  }
+}
+```
+
+**Response 500:**
+
+```json
+{
+  "error": {
+    "code": "trigger_failed",
+    "message": "Failed to trigger job; see server logs",
+    "details": {}
+  }
+}
+```
+
+> Also returns `500` with `"scheduler_unavailable"` if the scheduler is not
+> configured.
+
+### 4.9. `GET /api/v1/jobs/{id}/runs/latest`
+
+Returns the most recent execution record for a job. Useful for polling job
+progress after triggering via `POST /api/v1/jobs/trigger`.
+
+The `{id}` parameter uses dot-notation (e.g., `update.full`, `update.security`).
+
+**Response 200 (running):**
+
+```json
+{
+  "job_id": "update.full",
+  "status": "running",
+  "started_at": "2026-03-02T00:10:00Z"
+}
+```
+
+**Response 200 (completed):**
+
+```json
+{
+  "job_id": "update.full",
+  "status": "completed",
+  "started_at": "2026-03-02T00:10:00Z",
+  "ended_at": "2026-03-02T00:10:45Z",
+  "duration": "45s"
+}
+```
+
+**Response 200 (failed):**
+
+```json
+{
+  "job_id": "update.full",
+  "status": "failed",
+  "started_at": "2026-03-02T00:10:00Z",
+  "ended_at": "2026-03-02T00:10:03Z",
+  "error": "job failed; see server logs",
+  "duration": "3s"
+}
+```
+
+**Response 404 (no runs):**
+
+```json
+{
+  "error": {
+    "code": "no_runs",
+    "message": "No runs recorded for job 'update.full'",
+    "details": {}
+  }
+}
+```
+
+**Response 404 (job not found):**
+
+```json
+{
+  "error": {
+    "code": "job_not_found",
+    "message": "Job 'unknown' not found",
+    "details": {}
+  }
+}
+```
+
+**Response 500:**
+
+```json
+{
+  "error": {
+    "code": "scheduler_unavailable",
+    "message": "Scheduler not configured",
     "details": {}
   }
 }


### PR DESCRIPTION
## Summary

Adds async job execution tracking and hardens the API layer.

### Changes

**Scheduler**
- \JobRun\ struct tracking status, timing, and errors
- \TriggerJobAsync()\ / \LatestRun()\ methods
- \inalizeRun()\ helper with \defer Unlock()\ to prevent panic-induced deadlock
- Applied to both \TriggerJobAsync\ and cron \	ick()\ goroutines

**API**
- \GET /api/v1/jobs/{id}/runs/latest\ endpoint for polling job progress
- \MaxBytesReader\ on trigger endpoint body
- Generic error messages in \	rigger_failed\ and \invalid_config\ responses (no internal error leakage)

**Tests** — 14 new tests (9 API + 5 scheduler) with polling helper
**Docs** — All missing error responses documented in API.md (400, 404, 500)

### Review

Fleet reviewed (20 agents round 1 + 5 targeted round 2). All findings addressed.