### PR TITLE
chore: bump cm-plugin-update to b1851e4 (closes #45)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22
-	github.com/msutara/cm-plugin-update v0.0.0-20260303005802-1ce45fdd2c05
+	github.com/msutara/cm-plugin-update v0.0.0-20260303095301-b1851e44707a
 	github.com/msutara/config-manager-tui v0.0.0-20260303005802-f6409b5761d9
 	github.com/msutara/config-manager-web v0.0.0-20260303005802-54e5b80116b4
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22 h1:7BkzVv8GJIIRutbp7RIJsJ60ydobN6BA9kypzuqcHgY=
 github.com/msutara/cm-plugin-network v0.0.0-20260228011010-2f23468e6c22/go.mod h1:gH2489bbikv5S0Vhbo6IMh7e6LjzzOhEfu5ctXdqkmQ=
-github.com/msutara/cm-plugin-update v0.0.0-20260303005802-1ce45fdd2c05 h1:bKvMFjj8lLjHmZ8tEB248XH9A8lwRuSc30mJle0/564=
-github.com/msutara/cm-plugin-update v0.0.0-20260303005802-1ce45fdd2c05/go.mod h1:y3NsGDXlRm9AOOtDWnYcEzpb+NBiTjVkh2c3iuzGwz0=
+github.com/msutara/cm-plugin-update v0.0.0-20260303095301-b1851e44707a h1:Ajrg1WpB2la1leOgCsWMo0YFBqw6ScKnSSdrolVGQqc=
+github.com/msutara/cm-plugin-update v0.0.0-20260303095301-b1851e44707a/go.mod h1:y3NsGDXlRm9AOOtDWnYcEzpb+NBiTjVkh2c3iuzGwz0=
 github.com/msutara/config-manager-tui v0.0.0-20260303005802-f6409b5761d9 h1:3wFwqItNdCLLao2U75P4F5wBh31cYFTpnCg6w7B81/A=
 github.com/msutara/config-manager-tui v0.0.0-20260303005802-f6409b5761d9/go.mod h1:6uXCYslCn+w5loswIVLcMnmJ9J1osp8BeQj6scmnlYI=
 github.com/msutara/config-manager-web v0.0.0-20260303005802-54e5b80116b4 h1:KOv7HombQaie9ocqIrC5nMPQ0LgXJtOykWeg9+WHqtw=


### PR DESCRIPTION
## Changes

Single-line go.mod bump pulling latest cm-plugin-update which includes:
- **update#21** (PR #21): Data race fixes — sync.Once for init, sync.RWMutex for config, running guard with 409 Conflict
- **update#22** (PR #22): Service robustness — 64KB log cap with truncation marker, hasAptRelease test coverage, multiline regex edge cases

## Issue #45 Status

All 9 code-level items from #45 verified as already fixed in prior PRs:
- [x] Config log: logs key only, not value
- [x] copyMap: documented as sufficient for JSON primitives
- [x] PluginConfig: method doesn't exist; uses CurrentConfig() with locking
- [x] LatestRun: deep copies *time.Time pointer
- [x] --connect URL: validates scheme and host
- [x] --connect + --headless: mutual exclusion enforced
- [x] MaxBytesReader: trailing data rejected
- [x] HTTP body: properly drained with io.Copy
- [x] /runs/latest: error sanitized to generic message

2 packaging items deferred to #51.

Closes #45