### PR TITLE
fix: chown dirs to root on upgrade from pre-0.4.0

### DIFF
--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -4,6 +4,8 @@ set -e
 # Create required directories.
 mkdir -p /var/log/cm /var/lib/cm /etc/cm
 chmod 750 /var/log/cm /var/lib/cm
+# Ensure root ownership (upgrades from pre-0.4.0 may have cm:cm).
+chown root:root /var/log/cm /var/lib/cm /etc/cm
 
 case "$1" in
     configure)


### PR DESCRIPTION
Fixes #51

Upgrades from versions that used a \cm\ service user may leave \/var/log/cm\, \/var/lib/cm\, \/etc/cm\ with \cm:cm\ ownership while the service now runs as root.

### Changes

- **postinst.sh**: Add \chown root:root\ after directory creation to fix ownership on upgrade

### Notes

- Logrotate item from #51 was already fixed (shows \su root root\)
- This is the remaining packaging item